### PR TITLE
Fix .npmignore stripping dist/ from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,9 @@
 node_modules/
 .idea/
 npm-debug.log
-src/
-test/
+/src/
+/test/
+/dist/test/
 tsconfig.json
 .github
 *.zip


### PR DESCRIPTION
## Summary

The 2.3.0 npm tarball shipped with **no compiled JavaScript**. `npm pack --dry-run` on master shows only 7 files (README, TODO, biome.json, docker-compose.yml, logo.png, package.json, renovate.json) and zero files under `dist/`. This can be seen in [npmjs code browser](https://www.npmjs.com/package/raptor-journey-planner/v/2.3.0?activeTab=code).

## Root cause

`.npmignore` contained unanchored entries:

```
src/
test/
```

npm-packlist applies gitignore semantics, so these match **any** directory named `src` or `test` anywhere in the tree — including `dist/src/` and `dist/test/`. Since `tsc -p ./ --outDir dist/` emits to `dist/src/...`, the entire compiled tree was stripped on pack.

This was latent for years; the 2.3.0 modernization (#32) is the first version where it actually shipped to npm in this state — likely a combination of the new release workflow and newer npm-packlist semantics in CI Node 24.

## Fix

Anchor the patterns to the project root with a leading `/`, and add `/dist/test/` to keep tsc's compiled test files out of the published package (they're not part of the public API).

```diff
-src/
-test/
+/src/
+/test/
+/dist/test/
```

## Verification

Before (on master, with `dist/` populated by `tsc`):
```
npm notice total files: 7
npm notice unpacked size: 32.3 kB
```

After (this branch):
```
npm notice total files: 61
npm notice unpacked size: 96.2 kB
```

`dist/src/index.js` and `dist/src/index.d.ts` (the `main`/`types` entry points) are present, and `dist/test/` is absent.

## Test plan

- [ ] CI passes
- [ ] Maintainer runs `npm pack --dry-run` after `npm run prepublishOnly` and confirms `dist/src/index.js` is listed
- [ ] Bump patch version (suggest 2.3.1) and re-publish so consumers get a working package

(🤖 Generated with [Claude Code](https://claude.com/claude-code), I hope this does not disturb you too much. Kindly tell me if you prefer human-only written PR.)