### PR TITLE
Do not board a route at a stop it only sets down at

### DIFF
--- a/src/raptor/RaptorAlgorithm.ts
+++ b/src/raptor/RaptorAlgorithm.ts
@@ -39,7 +39,7 @@ export class RaptorAlgorithm {
 
   private scanRoutes(results: ScanResults, routeScanner: RouteScanner, markedStops: StopIdx[]): void {
     const {
-      arrivals, dropOff, interchange, routeStopOffsets, routeStops, routeTrips, stopTimesBase
+      arrivals, dropOff, interchange, pickUp, routeStopOffsets, routeStops, routeTrips, stopTimesBase
     } = this.timetable;
 
     for (const [route, startPosition] of buildQueue(this.timetable, markedStops)) {
@@ -61,7 +61,9 @@ export class RaptorAlgorithm {
           if (dropOff[stopsBase + pi] === 1 && arrival < results.bestArrival(stop)) {
             results.setTrip(routeTrips[route][trip], boardingPoint, pi, stop, arrival);
           }
-          else if (previousArrival !== NOT_REACHED && previousArrival < arrival) {
+          // reaching the stop earlier by other means may make an earlier trip on this route
+          // catchable, but only where the route picks passengers up
+          else if (pickUp[stopsBase + pi] === 1 && previousArrival !== NOT_REACHED && previousArrival < arrival) {
             const newTrip = routeScanner.getTrip(route, pi, previousArrival);
 
             if (newTrip !== NO_TRIP) {
@@ -71,7 +73,7 @@ export class RaptorAlgorithm {
             }
           }
         }
-        else if (previousArrival !== NOT_REACHED) {
+        else if (pickUp[stopsBase + pi] === 1 && previousArrival !== NOT_REACHED) {
           const newTrip = routeScanner.getTrip(route, pi, previousArrival);
 
           if (newTrip !== NO_TRIP) {

--- a/src/raptor/Timetable.ts
+++ b/src/raptor/Timetable.ts
@@ -49,7 +49,7 @@ export interface Timetable {
   /** Stop index to stop id, the inverse of stopIndex. Its length is the number of stops */
   stopIds: StopID[];
 
-  /** Bounds of each route's slice of routeStops and dropOff. Its length is the number of routes + 1 */
+  /** Bounds of each route's slice of routeStops, dropOff and pickUp. Its length is the number of routes + 1 */
   routeStopOffsets: Int32Array;
   /** Concatenated stop sequences of every route */
   routeStops: Int32Array;
@@ -58,6 +58,8 @@ export interface Timetable {
    * of the route signature, so every trip on a route shares this pattern.
    */
   dropOff: Uint8Array;
+  /** Parallel to routeStops, 1 where the route picks passengers up */
+  pickUp: Uint8Array;
 
   /** Offset of each route's slice of arrivals and departures. Its length is the number of routes + 1 */
   stopTimesBase: Int32Array;
@@ -225,6 +227,7 @@ export function createTimetable(
 
   const routeStops = new Int32Array(routeStopOffsets[numRoutes]);
   const dropOff = new Uint8Array(routeStopOffsets[numRoutes]);
+  const pickUp = new Uint8Array(routeStopOffsets[numRoutes]);
   const arrivals = new Int32Array(stopTimesBase[numRoutes]);
   const departures = new Int32Array(stopTimesBase[numRoutes]);
 
@@ -237,6 +240,7 @@ export function createTimetable(
       routeStops[stopsBase + p] = stops[p];
       // set down is part of the route signature, so any trip on the route gives the same answer
       dropOff[stopsBase + p] = trips[0].stopTimes[p].dropOff ? 1 : 0;
+      pickUp[stopsBase + p] = trips[0].stopTimes[p].pickUp ? 1 : 0;
     }
 
     for (let t = 0; t < trips.length; t++) {
@@ -295,6 +299,7 @@ export function createTimetable(
     routeStopOffsets,
     routeStops,
     dropOff,
+    pickUp,
     stopTimesBase,
     arrivals,
     departures,

--- a/test/unit/query/DepartAfterQuery.spec.ts
+++ b/test/unit/query/DepartAfterQuery.spec.ts
@@ -92,6 +92,48 @@ describe("DepartAfterQuery", () => {
     ]);
   });
 
+  it("does not board at a stop the route only sets down at", () => {
+    const trips = [
+      // B is set down only, so the only way onto this route is at A
+      t(
+        st("A", null, 600),
+        st("B", 700, null),
+        st("C", 800, null)
+      ),
+      t(
+        st("X", null, 800),
+        st("A", 900, null)
+      ),
+      t(
+        st("X", null, 810),
+        st("B", 950, null)
+      ),
+      t(
+        st("A", null, 1000),
+        st("B", 1100, null),
+        st("C", 1200, null)
+      )
+    ];
+
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const query = new DepartAfterQuery(raptor, journeyFactory);
+    const result = query.plan("X", "C", new Date("2018-10-16"), 700);
+
+    setDefaultTrip(result);
+
+    // reaching B at 950 must not let the journey join the 1000 from A there, it has to board at A
+    expect(result).toEqual([
+      j([
+        st("X", null, 800),
+        st("A", 900, null)
+      ], [
+        st("A", null, 1000),
+        st("B", 1100, null),
+        st("C", 1200, null)
+      ])
+    ]);
+  });
+
   it("does not return journeys that cannot be made", () => {
     const trips = [
       t(


### PR DESCRIPTION
`buildQueue` only ever starts a route at a position where it picks up, but `scanRoutes` carries on past that position and can take an earlier trip at *any* stop it had already reached by other means — without checking whether the route picks up there.

So a journey could board at a set down only stop, or at a stop the trip merely passes through.

### Reproduction

The new test in `DepartAfterQuery.spec.ts` covers it. `B` is set down only on the route `A -> B -> C`:

- round 1 reaches `A` at 900 and, by a different route, `B` at 950
- round 2 queues the route from `A` and boards the 1000, reaching `B` at 1100
- `B` is already reached sooner (950), so the scan falls through to the re-boarding branch and moves the boarding point to `B`

The journey then claims to board the train at `B`, which nobody can do. Without the fix the leg comes back with `origin: "B"` instead of `"A"`.

### Fix

Both boarding branches check a pick up flag, held in a new `Uint8Array` parallel to `dropOff`. Pick up is part of the route signature, so as with set down every trip on a route shares the pattern and it can be read once per position.

### Impact

Replanning 63 queries against a full GB rail feed returns byte-identical journeys, so nothing valid is lost — the guard only removes boardings that were never possible. Planning time is unchanged within noise (before 2240–2439ms, after 2182–2489ms over three runs each).

https://claude.ai/code/session_01SNukVhJ15ygSNPs3iNf5Sf