### PR TITLE
Return no results for a stop the feed does not have

### DIFF
--- a/src/query/GroupStationDepartAfterQuery.ts
+++ b/src/query/GroupStationDepartAfterQuery.ts
@@ -84,7 +84,9 @@ export class GroupStationDepartAfterQuery {
     destinations: StopID[]
   ): Journey[] {
 
-    const destinationsWithResults = destinations.filter(d => Object.keys(kConnections[d]).length > 0);
+    // a destination the feed has no stop for is simply not reachable, which is already how an
+    // origin the feed has no stop for is treated
+    const destinationsWithResults = destinations.filter(d => Object.keys(kConnections[d] ?? {}).length > 0);
     const initialResults = destinationsWithResults.flatMap(d => this.resultsFactory.getResults(kConnections, d));
 
     // reverse the previous connections and then work back through each day pre-pending journeys

--- a/test/unit/query/GroupStationDepartAfterQuery.spec.ts
+++ b/test/unit/query/GroupStationDepartAfterQuery.spec.ts
@@ -9,6 +9,60 @@ describe("GroupStationDepartAfterQuery", () => {
   const journeyFactory = new JourneyFactory();
   const filters = [new MultipleCriteriaFilter()];
 
+  it("returns no results for a destination the feed has no stop for", () => {
+    const trips = [
+      t(
+        st("A", null, 1000),
+        st("B", 1030, 1035),
+        st("C", 1100, null)
+      )
+    ];
+
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
+
+    expect(query.plan(["A"], ["Z"], new Date("2019-04-18"), 900)).toEqual([]);
+  });
+
+  it("still plans to the destinations the feed does have", () => {
+    const trips = [
+      t(
+        st("A", null, 1000),
+        st("B", 1030, 1035),
+        st("C", 1100, null)
+      )
+    ];
+
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
+    const result = query.plan(["A"], ["Z", "C"], new Date("2019-04-18"), 900);
+
+    setDefaultTrip(result);
+
+    expect(result).toEqual([
+      j([
+        st("A", null, 1000),
+        st("B", 1030, 1035),
+        st("C", 1100, null)
+      ])
+    ]);
+  });
+
+  it("returns no results for an origin the feed has no stop for", () => {
+    const trips = [
+      t(
+        st("A", null, 1000),
+        st("B", 1030, 1035),
+        st("C", 1100, null)
+      )
+    ];
+
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
+
+    expect(query.plan(["Z"], ["C"], new Date("2019-04-18"), 900)).toEqual([]);
+  });
+
   it("plans to multiple destinations", () => {
     const trips = [
       t(


### PR DESCRIPTION
Planning to a destination that has no stop in the feed throws instead of returning no results:

```
TypeError: Cannot convert undefined or null to object
    at GroupStationDepartAfterQuery.getJourneysFromConnections (GroupStationDepartAfterQuery.ts:87)
```

`ScanResults.finalize` builds the connection index from the timetable's stops, so a stop id that isn't in the feed has no entry at all and `Object.keys(kConnections[d])` blows up.

### Why silently, rather than throwing

The scan already drops unknown *origins* without complaint — `RaptorAlgorithm.scan` filters them out of the marked stops, and `ScanResults` skips them when seeding round zero. An unknown destination now means the same thing: not reachable, so no results. Passing a mixture of known and unknown destinations still plans to the ones that exist.

If you'd rather it failed loudly, that's a different change and wants to be a validation call the caller makes before planning, not an exception thrown from three frames deep in the reducer.

### Scope

`DepartAfterQuery` and `RangeQuery` both delegate here, so all three query classes are covered by the one guard. The other `kConnections[...]` lookups iterate keys of the index itself rather than caller input, so they can't hit this.

Three tests, covering an unknown destination, an unknown origin, and a mixture. Without the guard the first two fail with the `TypeError` above.

https://claude.ai/code/session_01SNukVhJ15ygSNPs3iNf5Sf