### PR TITLE
Plan on stations rather than platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,28 @@ Additional features not in the paper implementation:
  - Pickup / set down marker of stop times are obeyed
  - Multi-criteria journey filtering
  - Taking a footpath counts towards the number of changes (journey legs)
- 
+ - Journeys are planned between stations, and platforms are retained for display
+
+## Stops and stations
+
+Journeys are planned between stations, because that is where interchange time and transfers are
+defined and the only place a change of vehicle is possible. `loadGTFS` returns stops as the feed
+gives them; they are resolved when the timetable is created, following `parent_station` up through
+however many levels of grouping the feed uses. Pass the stop index to
+`RaptorAlgorithmFactory.create` and this happens for you.
+
+Stations are identified by their `stop_code`, falling back to `stop_id` where a feed does not give
+one. That is the identifier queries are made with and journeys are returned in. A feed that
+identifies platforms has to give its stations ids of its own, and `stop_code` is where it puts the
+code the station is actually known by — a CRS code for UK rail. GTFS places no uniqueness
+requirement on `stop_code`, so a feed that gives two stations the same one is rejected when the
+timetable is created, rather than silently planning them as the same place.
+
+Nothing is lost. Each stop time keeps the feed's `stop_id` as `platformStop`, and each trip keeps
+its full stopping pattern as `allStopTimes`. The legs of a journey are cut from that pattern, so
+they include the passing points between the stop boarded at and the stop alighted at. Filter on
+`pickUp` or `dropOff` for the calls a passenger can use.
+
 ## Usage
 
 It will work with any well-formed GTFS data set.
@@ -35,8 +56,8 @@ Find the first results that depart after a specific time
 const fs = require("fs");
 const {loadGTFS, JourneyFactory, RaptorAlgorithmFactory, DepartAfterQuery} = require("raptor-journey-planner");
 
-const [trips, transfers, interchange] = await loadGTFS(fs.createReadStream("gtfs.zip"));
-const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+const [trips, transfers, interchange, stops] = await loadGTFS(fs.createReadStream("gtfs.zip"));
+const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
 const resultsFactory = new JourneyFactory();
 const query = new DepartAfterQuery(raptor, resultsFactory);
 const journeys = query.plan("NRW", "STA", new Date(), 9 * 60 * 60);
@@ -50,8 +71,8 @@ Find results from multiple origin and destinations
 const fs = require("fs");
 const {loadGTFS, JourneyFactory, RaptorAlgorithmFactory, GroupStationDepartAfterQuery} = require("raptor-journey-planner");
 
-const [trips, transfers, interchange] = await loadGTFS(fs.createReadStream("gtfs.zip"));
-const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+const [trips, transfers, interchange, stops] = await loadGTFS(fs.createReadStream("gtfs.zip"));
+const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
 const resultsFactory = new JourneyFactory();
 const query = new GroupStationDepartAfterQuery(raptor, resultsFactory);
 const journeys = query.plan(["NRW"], ["LST", "EUS"], new Date(), 9 * 60 * 60);
@@ -65,8 +86,8 @@ Find results departing between a time range
 const fs = require("fs");
 const {loadGTFS, JourneyFactory, RaptorAlgorithmFactory, RangeQuery} = require("raptor-journey-planner");
 
-const [trips, transfers, interchange] = await loadGTFS(fs.createReadStream("gtfs.zip"));
-const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+const [trips, transfers, interchange, stops] = await loadGTFS(fs.createReadStream("gtfs.zip"));
+const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
 const resultsFactory = new JourneyFactory();
 const query = new RangeQuery(raptor, resultsFactory);
 const journeys = query.plan("NRW", "LST", new Date(), 9 * 60 * 60, 11 * 60 * 60);
@@ -80,8 +101,8 @@ Finds transfer patterns for a stop on a given date
 const fs = require("fs");
 const {loadGTFS, StringResults, RaptorAlgorithmFactory, TransferPatternQuery} = require("raptor-journey-planner");
 
-const [trips, transfers, interchange] = await loadGTFS(fs.createReadStream("gtfs.zip"));
-const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+const [trips, transfers, interchange, stops] = await loadGTFS(fs.createReadStream("gtfs.zip"));
+const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
 const resultsFactory = () => new StringResults();
 const query = new TransferPatternQuery(raptor, resultsFactory);
 const journeys = query.plan("NRW", new Date());
@@ -95,8 +116,8 @@ By default the multi-criteria filter will keep journeys as long as there are no 
 const fs = require("fs");
 const {loadGTFS, JourneyFactory, RaptorAlgorithmFactory, RangeQuery, MultipleCriteriaFilter} = require("raptor-journey-planner");
 
-const [trips, transfers, interchange] = await loadGTFS(fs.createReadStream("gtfs.zip"));
-const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+const [trips, transfers, interchange, stops] = await loadGTFS(fs.createReadStream("gtfs.zip"));
+const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
 const resultsFactory = new JourneyFactory();
 const filter = new MultipleCriteriaFilter();
 const maxSearchDays = 3;

--- a/src/gtfs/GTFS.ts
+++ b/src/gtfs/GTFS.ts
@@ -19,7 +19,10 @@ export type Duration = number;
  * GTFS stop time
  */
 export interface StopTime {
+  /** The station the call is at, once the timetable has resolved it from the feed's stop */
   stop: StopID;
+  /** The stop_id as it appears in the feed, which may identify a platform */
+  platformStop?: StopID;
   arrivalTime: Time;
   departureTime: Time;
   pickUp: boolean;
@@ -66,7 +69,10 @@ export type ServiceID = string;
  */
 export interface Trip {
   tripId: TripID;
+  /** Calls a passenger can use, which is what the algorithm plans with */
   stopTimes: StopTime[];
+  /** Every call of the trip, including the passing points filtered out of stopTimes */
+  allStopTimes?: StopTime[];
   serviceId: ServiceID;
   service: Service;
 }
@@ -113,7 +119,10 @@ export interface Stop {
   description: string,
   latitude: number,
   longitude: number,
-  timezone: string
+  timezone: string,
+  locationType: number,
+  parentStation?: StopID,
+  platformCode?: string
 }
 
 /**

--- a/src/gtfs/GTFSLoader.ts
+++ b/src/gtfs/GTFSLoader.ts
@@ -8,6 +8,9 @@ import { Service } from "./Service";
 
 /**
  * Returns trips, transfers, interchange time and calendars from a GTFS zip.
+ *
+ * Stops are returned as the feed gives them. Resolving them to the stations the algorithm plans
+ * between is done when the timetable is created.
  */
 export function loadGTFS(stream: Readable): Promise<GTFSData> {
   const timeParser = new TimeParser();
@@ -17,19 +20,28 @@ export function loadGTFS(stream: Readable): Promise<GTFSData> {
   const calendars: CalendarIndex = {};
   const dates = {};
   const stopTimes = {};
-  const stops = {};
+  const stops: StopIndex = {};
 
-  const processor = {
-    link: row => {
+  const addTransfer = (row, duration: number, startTime: number, endTime: number) => {
+    if (row.from_stop_id === row.to_stop_id) {
+      interchange[row.from_stop_id] = duration;
+    }
+    else {
       const t = {
         origin: row.from_stop_id,
         destination: row.to_stop_id,
-        duration: +row.duration,
-        startTime: timeParser.getTime(row.start_time),
-        endTime: timeParser.getTime(row.end_time)
+        duration,
+        startTime,
+        endTime
       };
 
       pushNested(t, transfers, row.from_stop_id);
+    }
+  };
+
+  const processor = {
+    link: row => {
+      addTransfer(row, +row.duration, timeParser.getTime(row.start_time), timeParser.getTime(row.end_time));
     },
     calendar: row => {
       calendars[row.service_id] = {
@@ -67,20 +79,13 @@ export function loadGTFS(stream: Readable): Promise<GTFSData> {
       pushNested(stopTime, stopTimes, row.trip_id);
     },
     transfer: row => {
-      if (row.from_stop_id === row.to_stop_id) {
-        interchange[row.from_stop_id] = +row.min_transfer_time;
-      }
-      else {
-        const t = {
-          origin: row.from_stop_id,
-          destination: row.to_stop_id,
-          duration: +row.min_transfer_time,
-          startTime: 0,
-          endTime: Number.MAX_SAFE_INTEGER
-        };
-
-        pushNested(t, transfers, row.from_stop_id);
-      }
+      // a feed that puts the footpaths in transfers.txt rather than links.txt gives them a window
+      addTransfer(
+        row,
+        +row.min_transfer_time,
+        row.start_time ? timeParser.getTime(row.start_time) : 0,
+        row.end_time ? timeParser.getTime(row.end_time) : Number.MAX_SAFE_INTEGER
+      );
     },
     stop: row => {
       const stop = {
@@ -90,7 +95,10 @@ export function loadGTFS(stream: Readable): Promise<GTFSData> {
         description: row.stop_desc,
         latitude: +row.stop_lat,
         longitude: +row.stop_lon,
-        timezone: row.zone_id
+        timezone: row.zone_id,
+        locationType: +(row.location_type ?? 0),
+        parentStation: row.parent_station,
+        platformCode: row.platform_code
       };
 
       setNested(stop, stops, row.stop_id);
@@ -109,7 +117,7 @@ export function loadGTFS(stream: Readable): Promise<GTFSData> {
         }
 
         for (const t of trips) {
-          t.stopTimes = stopTimes[t.tripId];
+          t.stopTimes = stopTimes[t.tripId] || [];
           t.service = services[t.serviceId];
         }
 

--- a/src/raptor/Normalise.ts
+++ b/src/raptor/Normalise.ts
@@ -1,0 +1,120 @@
+import type { StopID, StopIndex, Trip, Stop } from "../gtfs/GTFS";
+import type { Interchange, TransfersByOrigin } from "./RaptorAlgorithm";
+import { pushNested } from "ts-array-utils";
+
+/**
+ * A feed may group stops under a station and those under a station in turn, so the walk up is
+ * bounded rather than assumed to terminate.
+ */
+const MAX_PARENT_DEPTH = 10;
+
+/**
+ * Puts the feed into the terms the algorithm plans in: calls are at stations rather than platforms,
+ * and only the calls a passenger can use are kept.
+ *
+ * Interchange time and transfers are defined at the station and a change of vehicle is only
+ * possible there, so a feed that identifies platforms individually has to be resolved to the
+ * station before it can be planned with.
+ *
+ * Nothing is discarded. Each stop time keeps the feed's stop id as platformStop and each trip
+ * keeps its full stopping pattern, including passing points, as allStopTimes.
+ *
+ * The trips are rewritten in place, and running twice over the same trips is a no op.
+ */
+export function normalise(
+  trips: Trip[],
+  transfers: TransfersByOrigin,
+  interchange: Interchange,
+  stops: StopIndex
+): TimetableInput {
+
+  const stations = stationCodes(stops);
+  const station = (id: StopID): StopID => stations.get(id) ?? id;
+  const stationTrips: Trip[] = [];
+
+  for (const trip of trips) {
+    const allStopTimes = trip.allStopTimes ?? trip.stopTimes ?? [];
+
+    for (const stopTime of allStopTimes) {
+      const id = stopTime.platformStop ?? stopTime.stop;
+
+      // take the ids from the stop index so every call at a stop shares one string
+      stopTime.platformStop = stops[id]?.id ?? id;
+      stopTime.stop = station(id);
+    }
+
+    trip.allStopTimes = allStopTimes;
+    trip.stopTimes = allStopTimes.filter(stopTime => stopTime.pickUp || stopTime.dropOff);
+
+    // a trip that cannot be both boarded and alighted is of no use
+    if (trip.stopTimes.length > 1) {
+      stationTrips.push(trip);
+    }
+  }
+
+  const stationTransfers: TransfersByOrigin = {};
+  const stationInterchange: Interchange = {};
+
+  for (const stop of Object.keys(interchange)) {
+    stationInterchange[station(stop)] = interchange[stop];
+  }
+
+  for (const origin of Object.keys(transfers)) {
+    for (const transfer of transfers[origin]) {
+      const from = station(transfer.origin);
+      const to = station(transfer.destination);
+
+      // moving between two platforms of one station is what interchange time is for
+      if (from !== to) {
+        pushNested({ ...transfer, origin: from, destination: to }, stationTransfers, from);
+      }
+    }
+  }
+
+  return { trips: stationTrips, transfers: stationTransfers, interchange: stationInterchange };
+}
+
+/**
+ * Maps every stop to the station it belongs to, named by the station's stop_code where the feed
+ * gives one. That is the identifier the algorithm plans with.
+ *
+ * GTFS puts no uniqueness requirement on stop_code, so two stations sharing one are rejected
+ * rather than planned as the same place.
+ */
+function stationCodes(stops: StopIndex): Map<StopID, StopID> {
+  const claimed = new Map<StopID, StopID>();
+  const stations = new Map<StopID, StopID>();
+
+  for (const stop of Object.values(stops)) {
+    const station = resolveStation(stops, stop);
+    const code = station.code ?? station.id;
+    const owner = claimed.get(code);
+
+    if (owner !== undefined && owner !== station.id) {
+      throw new Error(`Stops ${owner} and ${station.id} both have the stop_code ${code}, which identifies the station`);
+    }
+
+    claimed.set(code, station.id);
+    stations.set(stop.id, code);
+  }
+
+  return stations;
+}
+
+function resolveStation(stops: StopIndex, stop: Stop, depth = 0): Stop {
+  if (depth < MAX_PARENT_DEPTH && stop.parentStation && stops[stop.parentStation]) {
+    return resolveStation(stops, stops[stop.parentStation], depth + 1)
+  } else {
+    return stop;
+  }
+}
+
+/**
+ * What the timetable is built from, once the feed has been put into the terms the algorithm plans
+ * in.
+ */
+export interface TimetableInput {
+  trips: Trip[];
+  transfers: TransfersByOrigin;
+  interchange: Interchange;
+}

--- a/src/raptor/RaptorAlgorithmFactory.ts
+++ b/src/raptor/RaptorAlgorithmFactory.ts
@@ -1,4 +1,4 @@
-import type { DayOfWeek, Trip } from "../gtfs/GTFS";
+import type { DayOfWeek, StopIndex, Trip } from "../gtfs/GTFS";
 import { type Interchange, RaptorAlgorithm, type TransfersByOrigin } from "./RaptorAlgorithm";
 import { getDateNumber } from "../query/DateUtil";
 import { createTimetable } from "./Timetable";
@@ -14,11 +14,15 @@ export class RaptorAlgorithmFactory {
    *
    * If a date is passed all trips will be filtered to ensure they run on that date. This improves query performance
    * but reduces flexibility
+   *
+   * The stop index is what a feed identifying platforms individually is resolved against, and the
+   * stations it gives are the stops queries are made with and journeys are returned in.
    */
   public static create(
     trips: Trip[],
     transfers: TransfersByOrigin,
     interchange: Interchange,
+    stops: StopIndex,
     date?: Date
   ): RaptorAlgorithm {
 
@@ -29,8 +33,6 @@ export class RaptorAlgorithmFactory {
       trips = trips.filter(trip => trip.service.runsOn(dateNumber, dow));
     }
 
-    trips.sort((a, b) => a.stopTimes[0].departureTime - b.stopTimes[0].departureTime);
-
-    return new RaptorAlgorithm(createTimetable(trips, transfers, interchange));
+    return new RaptorAlgorithm(createTimetable(trips, transfers, interchange, stops));
   }
 }

--- a/src/raptor/Timetable.ts
+++ b/src/raptor/Timetable.ts
@@ -1,15 +1,6 @@
-import type { StopID, StopTime, Time, Transfer, Trip } from "../gtfs/GTFS";
+import type { StopID, StopIndex, StopTime, Time, Transfer, Trip } from "../gtfs/GTFS";
+import { normalise } from "./Normalise";
 import type { Interchange, TransfersByOrigin } from "./RaptorAlgorithm";
-
-/**
- * Dense index assigned to a stop, in the range [0, number of stops).
- */
-export type StopIdx = number;
-
-/**
- * Dense index assigned to a route, in the range [0, number of routes).
- */
-export type RouteIdx = number;
 
 /**
  * Arrival time used for a stop that has not been reached. Chosen to be larger than any real
@@ -17,196 +8,26 @@ export type RouteIdx = number;
  */
 export const NOT_REACHED = 0x7fffffff;
 
-/**
- * A transfer paired with its destination resolved to a stop index. The transfer itself is the one
- * given to the factory, which is what ends up in the returned journeys.
- */
-export interface IndexedTransfer {
-  destination: StopIdx;
-  transfer: Transfer;
-}
-
-/**
- * The timetable in the "global array" form described by the Raptor paper: every stop and route is
- * a dense integer index, and everything the scan reads is a flat typed array indexed by those
- * integers. This removes the string hashing and pointer chasing from the hot path.
- *
- * Variable length data is concatenated into a single flat array, with an offsets array giving the
- * bounds of each slice. Route `r` owns `[routeStopOffsets[r], routeStopOffsets[r + 1])` of
- * routeStops, so the offsets array has one more entry than there are routes and the length of a
- * slice is the gap between two offsets:
- *
- *   stopsInRoute                     routeStopOffsets[r + 1] - routeStopOffsets[r]
- *   stop at position p of route r    routeStops[routeStopOffsets[r] + p]
- *   arrival of trip t at position p  arrivals[stopTimesBase[r] + t * stopsInRoute + p]
- *
- * The number of stops and routes is the length of the arrays holding them, so it is not stored
- * separately.
- */
-export interface Timetable {
-  /** Stop id to stop index, used to translate queries in and results out */
-  stopIndex: Map<StopID, StopIdx>;
-  /** Stop index to stop id, the inverse of stopIndex. Its length is the number of stops */
-  stopIds: StopID[];
-
-  /** Bounds of each route's slice of routeStops, dropOff and pickUp. Its length is the number of routes + 1 */
-  routeStopOffsets: Int32Array;
-  /** Concatenated stop sequences of every route */
-  routeStops: Int32Array;
-  /**
-   * Parallel to routeStops, 1 where the route sets down passengers. Pick up and set down are part
-   * of the route signature, so every trip on a route shares this pattern.
-   */
-  dropOff: Uint8Array;
-  /** Parallel to routeStops, 1 where the route picks passengers up */
-  pickUp: Uint8Array;
-
-  /** Offset of each route's slice of arrivals and departures. Its length is the number of routes + 1 */
-  stopTimesBase: Int32Array;
-  /** Concatenated trip-major arrival times of every route */
-  arrivals: Int32Array;
-  /** Concatenated trip-major departure times of every route */
-  departures: Int32Array;
-
-  /** Each route's trips in departure order, for the calendar check and journey reconstruction */
-  routeTrips: Trip[][];
-
-  /** Bounds of each stop's slice of stopRoutes and stopRoutePos. Its length is the number of stops + 1 */
-  stopRouteOffsets: Int32Array;
-  /** Concatenated lists of the routes picking up at each stop */
-  stopRoutes: Int32Array;
-  /** Parallel to stopRoutes, the position of that stop within that route */
-  stopRoutePos: Int32Array;
-
-  /** Minimum interchange time at each stop */
-  interchange: Int32Array;
-  /** Transfers available from each stop */
-  transfers: IndexedTransfer[][];
-}
-
 const DEFAULT_INTERCHANGE_TIME = 0;
 const OVERTAKING_ROUTE_SUFFIX = "|overtakes";
 
 /**
- * Trips grouped into routes, before they are flattened into the arrays above.
- */
-interface RouteGrouping {
-  stopIndex: Map<StopID, StopIdx>;
-  stopIds: StopID[];
-  /** Stop sequence of each route */
-  routeStops: StopIdx[][];
-  /** Trips on each route, in departure order */
-  routeTrips: Trip[][];
-  /** For each stop, the routes picking up there and the position of that stop within them */
-  stopRoutePositions: Map<RouteIdx, number>[];
-}
-
-/**
- * Two trips belong to the same route when they call at the same stops in the same order with the
- * same pick up and set down pattern.
- */
-function routeSignature(stops: StopIdx[], stopTimes: StopTime[]): string {
-  return stopTimes
-    .map((stopTime, i) => `${stops[i]},${stopTime.pickUp ? 1 : 0}${stopTime.dropOff ? 1 : 0}`)
-    .join("|");
-}
-
-function finalArrival(trip: Trip): Time {
-  return trip.stopTimes[trip.stopTimes.length - 1].arrivalTime;
-}
-
-/**
- * A trip overtakes a route when it arrives earlier than a trip that departed before it. Raptor
- * needs the trips on a route to be ordered, so an overtaking trip is put on a route of its own.
- */
-function overtakes(trip: Trip, routeTrips: Trip[]): boolean {
-  for (const other of routeTrips) {
-    if (finalArrival(trip) < finalArrival(other)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/**
- * Assign every stop and route a dense index and group the trips onto their routes.
- */
-function groupTripsIntoRoutes(trips: Trip[], transfers: TransfersByOrigin): RouteGrouping {
-  const stopIndex = new Map<StopID, StopIdx>();
-  const stopIds: StopID[] = [];
-  const stopRoutePositions: Map<RouteIdx, number>[] = [];
-
-  const internStop = (stop: StopID): StopIdx => {
-    let index = stopIndex.get(stop);
-
-    if (index === undefined) {
-      index = stopIds.length;
-      stopIndex.set(stop, index);
-      stopIds.push(stop);
-      stopRoutePositions.push(new Map());
-    }
-
-    return index;
-  };
-
-  const routeIndex = new Map<string, RouteIdx>();
-  const routeStops: StopIdx[][] = [];
-  const routeTrips: Trip[][] = [];
-
-  for (const trip of trips) {
-    const stopTimes = trip.stopTimes;
-    const stops = stopTimes.map(stopTime => internStop(stopTime.stop));
-
-    let signature = routeSignature(stops, stopTimes);
-    const existing = routeIndex.get(signature);
-
-    if (existing !== undefined && overtakes(trip, routeTrips[existing])) {
-      signature += OVERTAKING_ROUTE_SUFFIX;
-    }
-
-    let route = routeIndex.get(signature);
-
-    if (route === undefined) {
-      route = routeStops.length;
-      routeIndex.set(signature, route);
-      routeStops.push(stops);
-      routeTrips.push([]);
-
-      // walk backwards so that on a route calling at a stop twice, the earlier call wins
-      for (let p = stops.length - 1; p >= 0; p--) {
-        if (stopTimes[p].pickUp) {
-          stopRoutePositions[stops[p]].set(route, p);
-        }
-      }
-    }
-
-    routeTrips[route].push(trip);
-  }
-
-  // transfers can reach stops that no trip calls at, so they are interned after the trips
-  for (const origin of Object.keys(transfers)) {
-    internStop(origin);
-
-    for (const transfer of transfers[origin]) {
-      internStop(transfer.destination);
-    }
-  }
-
-  return { stopIndex, stopIds, routeStops, routeTrips, stopRoutePositions };
-}
-
-/**
- * Group the trips into routes and flatten the result into the global arrays above.
+ * Normalise the feed, group the trips into routes and flatten the result into the global arrays
+ * above.
  *
- * Trips must already be sorted by departure time: the trips of a route are laid out in that order
- * and the scan relies on it to walk backwards to the earliest reachable trip.
+ * The trips of a route are laid out in departure order and the scan relies on it to walk backwards
+ * to the earliest reachable trip, so they are sorted here rather than by the caller.
  */
 export function createTimetable(
-  trips: Trip[],
-  transfers: TransfersByOrigin,
-  interchange: Interchange
+  feedTrips: Trip[],
+  feedTransfers: TransfersByOrigin,
+  feedInterchange: Interchange,
+  stops: StopIndex
 ): Timetable {
+  const { trips, transfers, interchange } = normalise(feedTrips, feedTransfers, feedInterchange, stops);
+
+  trips.sort((a, b) => a.stopTimes[0].departureTime - b.stopTimes[0].departureTime);
+
   const { stopIndex, stopIds, routeStops: routeStopSeq, routeTrips, stopRoutePositions } =
     groupTripsIntoRoutes(trips, transfers);
 
@@ -310,4 +131,192 @@ export function createTimetable(
     interchange: interchangeTimes,
     transfers: indexedTransfers
   };
+}
+
+/**
+ * Assign every stop and route a dense index and group the trips onto their routes.
+ */
+function groupTripsIntoRoutes(trips: Trip[], transfers: TransfersByOrigin): RouteGrouping {
+  const stopIndex = new Map<StopID, StopIdx>();
+  const stopIds: StopID[] = [];
+  const stopRoutePositions: Map<RouteIdx, number>[] = [];
+
+  const internStop = (stop: StopID): StopIdx => {
+    let index = stopIndex.get(stop);
+
+    if (index === undefined) {
+      index = stopIds.length;
+      stopIndex.set(stop, index);
+      stopIds.push(stop);
+      stopRoutePositions.push(new Map());
+    }
+
+    return index;
+  };
+
+  const routeIndex = new Map<string, RouteIdx>();
+  const routeStops: StopIdx[][] = [];
+  const routeTrips: Trip[][] = [];
+  const routeLatestArrival: Time[] = [];
+
+  for (const trip of trips) {
+    const stopTimes = trip.stopTimes;
+    const stops = stopTimes.map(stopTime => internStop(stopTime.stop));
+
+    let signature = routeSignature(stops, stopTimes);
+    const existing = routeIndex.get(signature);
+
+    if (existing !== undefined && overtakes(trip, routeLatestArrival[existing])) {
+      signature += OVERTAKING_ROUTE_SUFFIX;
+    }
+
+    let route = routeIndex.get(signature);
+
+    if (route === undefined) {
+      route = routeStops.length;
+      routeIndex.set(signature, route);
+      routeStops.push(stops);
+      routeTrips.push([]);
+      routeLatestArrival.push(Number.MIN_SAFE_INTEGER);
+
+      // walk backwards so that on a route calling at a stop twice, the earlier call wins
+      for (let p = stops.length - 1; p >= 0; p--) {
+        if (stopTimes[p].pickUp) {
+          stopRoutePositions[stops[p]].set(route, p);
+        }
+      }
+    }
+
+    routeTrips[route].push(trip);
+
+    if (finalArrival(trip) > routeLatestArrival[route]) {
+      routeLatestArrival[route] = finalArrival(trip);
+    }
+  }
+
+  // transfers can reach stops that no trip calls at, so they are interned after the trips
+  for (const origin of Object.keys(transfers)) {
+    internStop(origin);
+
+    for (const transfer of transfers[origin]) {
+      internStop(transfer.destination);
+    }
+  }
+
+  return { stopIndex, stopIds, routeStops, routeTrips, stopRoutePositions };
+}
+
+/**
+ * Two trips belong to the same route when they call at the same stops in the same order with the
+ * same pick up and set down pattern.
+ */
+function routeSignature(stops: StopIdx[], stopTimes: StopTime[]): string {
+  return stopTimes
+    .map((stopTime, i) => `${stops[i]},${stopTime.pickUp ? 1 : 0}${stopTime.dropOff ? 1 : 0}`)
+    .join("|");
+}
+
+/**
+ * A trip overtakes a route when it arrives earlier than a trip that departed before it. Raptor
+ * needs the trips on a route to be ordered, so an overtaking trip is put on a route of its own.
+ *
+ * Trips are added in departure order, so comparing against the latest arrival so far is enough.
+ */
+function overtakes(trip: Trip, latestArrival: Time): boolean {
+  return finalArrival(trip) < latestArrival;
+}
+
+function finalArrival(trip: Trip): Time {
+  return trip.stopTimes[trip.stopTimes.length - 1].arrivalTime;
+}
+
+/**
+ * Dense index assigned to a stop, in the range [0, number of stops).
+ */
+export type StopIdx = number;
+
+/**
+ * Dense index assigned to a route, in the range [0, number of routes).
+ */
+export type RouteIdx = number;
+
+/**
+ * A transfer paired with its destination resolved to a stop index. The transfer itself is the one
+ * given to the factory, which is what ends up in the returned journeys.
+ */
+export interface IndexedTransfer {
+  destination: StopIdx;
+  transfer: Transfer;
+}
+
+/**
+ * The timetable in the "global array" form described by the Raptor paper: every stop and route is
+ * a dense integer index, and everything the scan reads is a flat typed array indexed by those
+ * integers. This removes the string hashing and pointer chasing from the hot path.
+ *
+ * Variable length data is concatenated into a single flat array, with an offsets array giving the
+ * bounds of each slice. Route `r` owns `[routeStopOffsets[r], routeStopOffsets[r + 1])` of
+ * routeStops, so the offsets array has one more entry than there are routes and the length of a
+ * slice is the gap between two offsets:
+ *
+ *   stopsInRoute                     routeStopOffsets[r + 1] - routeStopOffsets[r]
+ *   stop at position p of route r    routeStops[routeStopOffsets[r] + p]
+ *   arrival of trip t at position p  arrivals[stopTimesBase[r] + t * stopsInRoute + p]
+ *
+ * The number of stops and routes is the length of the arrays holding them, so it is not stored
+ * separately.
+ */
+export interface Timetable {
+  /** Stop id to stop index, used to translate queries in and results out */
+  stopIndex: Map<StopID, StopIdx>;
+  /** Stop index to stop id, the inverse of stopIndex. Its length is the number of stops */
+  stopIds: StopID[];
+
+  /** Bounds of each route's slice of routeStops, dropOff and pickUp. Its length is the number of routes + 1 */
+  routeStopOffsets: Int32Array;
+  /** Concatenated stop sequences of every route */
+  routeStops: Int32Array;
+  /**
+   * Parallel to routeStops, 1 where the route sets down passengers. Pick up and set down are part
+   * of the route signature, so every trip on a route shares this pattern.
+   */
+  dropOff: Uint8Array;
+  /** Parallel to routeStops, 1 where the route picks up */
+  pickUp: Uint8Array;
+
+  /** Offset of each route's slice of arrivals and departures. Its length is the number of routes + 1 */
+  stopTimesBase: Int32Array;
+  /** Concatenated trip-major arrival times of every route */
+  arrivals: Int32Array;
+  /** Concatenated trip-major departure times of every route */
+  departures: Int32Array;
+
+  /** Each route's trips in departure order, for the calendar check and journey reconstruction */
+  routeTrips: Trip[][];
+
+  /** Bounds of each stop's slice of stopRoutes and stopRoutePos. Its length is the number of stops + 1 */
+  stopRouteOffsets: Int32Array;
+  /** Concatenated lists of the routes picking up at each stop */
+  stopRoutes: Int32Array;
+  /** Parallel to stopRoutes, the position of that stop within that route */
+  stopRoutePos: Int32Array;
+
+  /** Minimum interchange time at each stop */
+  interchange: Int32Array;
+  /** Transfers available from each stop */
+  transfers: IndexedTransfer[][];
+}
+
+/**
+ * Trips grouped into routes, before they are flattened into the arrays above.
+ */
+interface RouteGrouping {
+  stopIndex: Map<StopID, StopIdx>;
+  stopIds: StopID[];
+  /** Stop sequence of each route */
+  routeStops: StopIdx[][];
+  /** Trips on each route, in departure order */
+  routeTrips: Trip[][];
+  /** For each stop, the routes picking up there and the position of that stop within them */
+  stopRoutePositions: Map<RouteIdx, number>[];
 }

--- a/src/results/JourneyFactory.ts
+++ b/src/results/JourneyFactory.ts
@@ -1,4 +1,4 @@
-import type { StopID, Time, TimetableLeg } from "../gtfs/GTFS";
+import type { StopID, StopTime, Time, TimetableLeg, Trip } from "../gtfs/GTFS";
 import { isTransfer, type ResultsFactory } from "./ResultsFactory";
 import type { ConnectionIndex } from "../raptor/ScanResults";
 import type { AnyLeg, Journey } from "./Journey";
@@ -40,7 +40,7 @@ export class JourneyFactory implements ResultsFactory {
         destination = connection.origin;
       } else {
         const [trip, start, end] = connection;
-        const stopTimes = trip.stopTimes.slice(start, end + 1);
+        const stopTimes = this.getStopTimes(trip, start, end);
         const origin = stopTimes[0].stop;
 
         legs.push({stopTimes, origin, destination, trip});
@@ -50,6 +50,27 @@ export class JourneyFactory implements ResultsFactory {
     }
 
     return legs.reverse();
+  }
+
+  /**
+   * The stop times the leg covers, including the passing points that were filtered out of the
+   * trip before it was planned with. A connection is boarded and alighted at a call, so those
+   * still bound the leg and only the calls between them gain company.
+   */
+  private getStopTimes(trip: Trip, start: number, end: number): StopTime[] {
+    const allStopTimes = trip.allStopTimes;
+
+    if (allStopTimes === undefined) {
+      return trip.stopTimes.slice(start, end + 1);
+    }
+
+    // stopTimes is a filtered view of allStopTimes, so the same objects bound the leg in both
+    const from = allStopTimes.indexOf(trip.stopTimes[start]);
+    const to = allStopTimes.indexOf(trip.stopTimes[end]);
+
+    return from === -1 || to === -1
+      ? trip.stopTimes.slice(start, end + 1)
+      : allStopTimes.slice(from, to + 1);
   }
 
   private getDepartureTime(legs: AnyLeg[]): Time {

--- a/src/transfer-pattern-worker.ts
+++ b/src/transfer-pattern-worker.ts
@@ -11,8 +11,8 @@ import * as mysql from "mysql2/promise";
  */
 async function worker(filename: string, date: Date): Promise<void> {
   const stream = fs.createReadStream(filename);
-  const [trips, transfers, interchange] = await loadGTFS(stream);
-  const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, date);
+  const [trips, transfers, interchange, stops] = await loadGTFS(stream);
+  const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops, date);
 
   const query = new TransferPatternQuery(raptor, () => new StringResults(interchange));
   const repository = new TransferPatternRepository(getDatabase());

--- a/src/transfer-patterns.ts
+++ b/src/transfer-patterns.ts
@@ -36,9 +36,13 @@ async function getStops(filename: string): Promise<StopID[]> {
 
     fs.createReadStream(filename)
         .pipe(gtfs({ raw: true }))
+        // only the stations, and named the way the algorithm names them. A feed that identifies
+        // platforms individually gives them the same timezone, so they are excluded by having a
+        // parent rather than by their timezone
         .on("data", entity => entity.type === "stop"
             && entity.data.stop_timezone === "Europe/London"
-            && stops.push(entity.data.stop_id)
+            && entity.data.parent_station === undefined
+            && stops.push(entity.data.stop_code ?? entity.data.stop_id)
         )
         .on("error", e => reject(e))
         .on("end", () => resolve(stops));

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -7,7 +7,7 @@ import { MultipleCriteriaFilter } from "../src/results/filter/MultipleCriteriaFi
 import { GroupStationDepartAfterQuery } from "../src/query/GroupStationDepartAfterQuery";
 
 async function run() {
-  const filename = process.argv[2] || "/home/linus/Downloads/gb-rail-latest.zip";
+  const filename = process.argv[2] || "gtfs.zip";
   console.log(`Loading ${filename}`);
   console.time("initial load");
   const stream = fs.createReadStream(filename);

--- a/test/integration.ts
+++ b/test/integration.ts
@@ -11,14 +11,15 @@ async function run() {
   console.log(`Loading ${filename}`);
   console.time("initial load");
   const stream = fs.createReadStream(filename);
-  const [trips, transfers, interchange] = await loadGTFS(stream);
+  const [trips, transfers, interchange, stops] = await loadGTFS(stream);
   console.timeEnd("initial load");
 
   console.time("pre-processing");
   const raptor = RaptorAlgorithmFactory.create(
     trips,
     transfers,
-    interchange
+    interchange,
+    stops
   );
 
   const query = new GroupStationDepartAfterQuery(

--- a/test/performance.ts
+++ b/test/performance.ts
@@ -64,11 +64,11 @@ const queries = [
 async function run() {
   console.time("initial load");
   const stream = fs.createReadStream("gtfs.zip");
-  const [trips, transfers, interchange] = await loadGTFS(stream);
+  const [trips, transfers, interchange, stops] = await loadGTFS(stream);
   console.timeEnd("initial load");
 
   console.time("pre-processing");
-  const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+  const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
   const query = new GroupStationDepartAfterQuery(raptor, new JourneyFactory());
   console.timeEnd("pre-processing");
 

--- a/test/transfer-patterns.ts
+++ b/test/transfer-patterns.ts
@@ -7,7 +7,7 @@ import { TransferPatternQuery } from "../src/query/TransferPatternQuery";
 async function run() {
   console.time("initial load");
   const stream = fs.createReadStream("/home/linus/Downloads/gb-rail-latest.zip");
-  const [trips, transfers, interchange] = await loadGTFS(stream);
+  const [trips, transfers, interchange, stops] = await loadGTFS(stream);
   console.timeEnd("initial load");
 
   console.time("pre-processing");
@@ -17,6 +17,7 @@ async function run() {
     trips,
     transfers,
     interchange,
+    stops,
     date
   );
 

--- a/test/unit/query/DepartAfterQuery.spec.ts
+++ b/test/unit/query/DepartAfterQuery.spec.ts
@@ -17,7 +17,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -46,7 +46,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -75,7 +75,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -88,6 +88,34 @@ describe("DepartAfterQuery", () => {
       ], [
         st("B", 1030, 1035),
         st("E", 1100, null)
+      ])
+    ]);
+  });
+
+  it("includes the points a leg passes through without calling at", () => {
+    const passing = st("P", 1030, 1030);
+    passing.pickUp = false;
+    passing.dropOff = false;
+
+    const trips = [
+      t(
+        st("A", null, 1000),
+        passing,
+        st("B", 1100, null)
+      )
+    ];
+
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
+    const query = new DepartAfterQuery(raptor, journeyFactory);
+    const result = query.plan("A", "B", new Date("2018-10-16"), 900);
+
+    setDefaultTrip(result);
+
+    expect(result).toEqual([
+      j([
+        st("A", null, 1000),
+        passing,
+        st("B", 1100, null)
       ])
     ]);
   });
@@ -115,7 +143,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("X", "C", new Date("2018-10-16"), 700);
 
@@ -148,7 +176,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 1);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -170,7 +198,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -220,7 +248,7 @@ describe("DepartAfterQuery", () => {
       ),
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -265,7 +293,7 @@ describe("DepartAfterQuery", () => {
       ),
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -308,7 +336,7 @@ describe("DepartAfterQuery", () => {
       ),
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -346,7 +374,7 @@ describe("DepartAfterQuery", () => {
       ]
     };
 
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -385,7 +413,7 @@ describe("DepartAfterQuery", () => {
       ]
     };
 
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "D", new Date("2018-10-16"), 900);
 
@@ -419,7 +447,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -450,7 +478,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -487,7 +515,7 @@ describe("DepartAfterQuery", () => {
     const transfers = {};
     const interchange = { B: 10 };
 
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -541,7 +569,7 @@ describe("DepartAfterQuery", () => {
 
     const interchange = { B: 10, C: 10 };
 
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "D", new Date("2018-10-16"), 900);
 
@@ -591,7 +619,7 @@ describe("DepartAfterQuery", () => {
 
     const transfers = {};
     const interchange = {};
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -639,7 +667,7 @@ describe("DepartAfterQuery", () => {
 
     const transfers = {};
     const interchange = {};
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-22"), 900);
 
@@ -685,7 +713,7 @@ describe("DepartAfterQuery", () => {
 
     const transfers = {};
     const interchange = {};
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-22"), 900);
 
@@ -731,7 +759,7 @@ describe("DepartAfterQuery", () => {
 
     const transfers = {};
     const interchange = {};
-    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange);
+    const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-22"), 900);
 
@@ -779,7 +807,7 @@ describe("DepartAfterQuery", () => {
       ),
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"), 900);
 
@@ -846,7 +874,7 @@ describe("DepartAfterQuery", () => {
       ),
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -881,7 +909,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 2);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -912,7 +940,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 2);
     const result = query.plan("A", "E", new Date("2018-10-16"), 900);
 
@@ -937,7 +965,7 @@ describe("DepartAfterQuery", () => {
 
     trips[1].service = services["2"];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 2);
     const result = query.plan("A", "E", new Date("2018-12-31"), 900);
 
@@ -967,7 +995,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 2);
     const result = query.plan("A", "E", new Date("2019-04-23"), 900);
 
@@ -1030,7 +1058,7 @@ describe("DepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new DepartAfterQuery(raptor, journeyFactory, 2);
     const result = query.plan("A", "E", new Date("2018-12-31"), 50000);
 

--- a/test/unit/query/GroupStationDepartAfterQuery.spec.ts
+++ b/test/unit/query/GroupStationDepartAfterQuery.spec.ts
@@ -18,7 +18,7 @@ describe("GroupStationDepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
 
     expect(query.plan(["A"], ["Z"], new Date("2019-04-18"), 900)).toEqual([]);
@@ -33,7 +33,7 @@ describe("GroupStationDepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
     const result = query.plan(["A"], ["Z", "C"], new Date("2019-04-18"), 900);
 
@@ -57,7 +57,7 @@ describe("GroupStationDepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
 
     expect(query.plan(["Z"], ["C"], new Date("2019-04-18"), 900)).toEqual([]);
@@ -77,7 +77,7 @@ describe("GroupStationDepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
     const result = query.plan(["A"], ["C", "D"], new Date("2019-04-18"), 900);
 
@@ -111,7 +111,7 @@ describe("GroupStationDepartAfterQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new GroupStationDepartAfterQuery(raptor, journeyFactory, 1, filters);
     const result = query.plan(["A", "B"], ["C", "D"], new Date("2019-04-18"), 900);
 

--- a/test/unit/query/RangeQuery.spec.ts
+++ b/test/unit/query/RangeQuery.spec.ts
@@ -26,7 +26,7 @@ describe("RangeQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new RangeQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"));
 
@@ -81,7 +81,7 @@ describe("RangeQuery", () => {
       )
     ];
 
-    const raptor = RaptorAlgorithmFactory.create(trips, {}, {});
+    const raptor = RaptorAlgorithmFactory.create(trips, {}, {}, {});
     const query = new RangeQuery(raptor, journeyFactory);
     const result = query.plan("A", "C", new Date("2018-10-16"));
 

--- a/test/unit/raptor/Timetable.spec.ts
+++ b/test/unit/raptor/Timetable.spec.ts
@@ -1,11 +1,30 @@
 import { describe, it, expect } from "vitest";
 import { createTimetable } from "../../../src/raptor/Timetable";
 import { st, t, tf } from "../util";
+import type { Stop, StopID, StopIndex } from "../../../src/gtfs/GTFS";
 
 describe("Timetable", () => {
 
+  function stop(id: StopID, code: string | undefined, locationType = 0, parentStation?: StopID): Stop {
+    return {
+      id,
+      code: code as string,
+      name: id,
+      description: "",
+      latitude: 0,
+      longitude: 0,
+      timezone: "Europe/London",
+      locationType,
+      parentStation
+    };
+  }
+
+  function stopIndex(...stops: Stop[]): StopIndex {
+    return stops.reduce((all, s) => { all[s.id] = s; return all; }, {} as StopIndex);
+  }
+
   it("assigns a dense index to every stop", () => {
-    const timetable = createTimetable([t(st("A", null, 1000), st("B", 1100, null))], {}, {});
+    const timetable = createTimetable([t(st("A", null, 1000), st("B", 1100, null))], {}, {}, {});
 
     expect(timetable.stopIds.length).toBe(2);
     expect(timetable.stopIds).toEqual(["A", "B"]);
@@ -17,7 +36,7 @@ describe("Timetable", () => {
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", 1100, null)),
       t(st("A", null, 2000), st("B", 2100, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     expect(timetable.routeTrips.length).toBe(1);
     expect(timetable.routeTrips[0].length).toBe(2);
@@ -28,7 +47,7 @@ describe("Timetable", () => {
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", 1100, null)),
       t(st("A", null, 2000), st("C", 2100, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     expect(timetable.routeTrips.length).toBe(2);
   });
@@ -38,7 +57,7 @@ describe("Timetable", () => {
       // departs first but arrives second, so the second trip overtakes it
       t(st("A", null, 1000), st("B", 3000, null)),
       t(st("A", null, 2000), st("B", 2500, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     expect(timetable.routeTrips.length).toBe(2);
     expect(timetable.routeTrips[0].length).toBe(1);
@@ -49,7 +68,7 @@ describe("Timetable", () => {
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", 1100, 1150), st("C", 1200, null)),
       t(st("A", null, 2000), st("B", 2100, 2150), st("C", 2200, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     const { arrivals, departures, routeStopOffsets, stopTimesBase } = timetable;
     const numStops = routeStopOffsets[1] - routeStopOffsets[0];
@@ -65,7 +84,7 @@ describe("Timetable", () => {
   it("records where each route sets down", () => {
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", null, 1150), st("C", 1200, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     expect(Array.from(timetable.routeStops)).toEqual([0, 1, 2]);
     expect(Array.from(timetable.dropOff)).toEqual([0, 0, 1]);
@@ -75,7 +94,7 @@ describe("Timetable", () => {
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", 1100, 1150), st("C", 1200, null)),
       t(st("B", null, 2000), st("C", 2100, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     const routesAt = (stop: number) => {
       const base = timetable.stopRouteOffsets[stop];
@@ -99,7 +118,7 @@ describe("Timetable", () => {
     // A is called at twice, so a scan starting from A must start at the first call, not the second
     const timetable = createTimetable([
       t(st("A", null, 1000), st("B", 1100, 1150), st("A", 1200, 1250), st("C", 1300, null))
-    ], {}, {});
+    ], {}, {}, {});
 
     const stop = timetable.stopIndex.get("A") as number;
     const base = timetable.stopRouteOffsets[stop];
@@ -114,6 +133,7 @@ describe("Timetable", () => {
     const timetable = createTimetable(
       [t(st("A", null, 1000), st("B", 1100, null))],
       { A: [transfer] },
+      {},
       {}
     );
 
@@ -129,6 +149,7 @@ describe("Timetable", () => {
     const timetable = createTimetable(
       [t(st("A", null, 1000), st("B", 1100, null))],
       { B: [tf("B", "C", 120)] },
+      {},
       {}
     );
 
@@ -141,11 +162,179 @@ describe("Timetable", () => {
     const timetable = createTimetable(
       [t(st("A", null, 1000), st("B", 1100, null))],
       {},
-      { B: 300 }
+      { B: 300 },
+      {}
     );
 
     expect(timetable.interchange[timetable.stopIndex.get("A") as number]).toBe(0);
     expect(timetable.interchange[timetable.stopIndex.get("B") as number]).toBe(300);
+  });
+
+  it("names a stop by the code of the station it belongs to", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4", null, 1000), st("9100DISS1", 1030, null))],
+      {},
+      {},
+      stopIndex(
+        stop("910GNRCH", "NRW", 1),
+        stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+        stop("910GDISS", "DIS", 1),
+        stop("9100DISS1", "DIS", 0, "910GDISS")
+      )
+    );
+
+    expect(timetable.stopIds).toEqual(["NRW", "DIS"]);
+  });
+
+  it("keeps the feed's stop on the stop time as the platform", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4", null, 1000), st("9100DISS1", 1030, null))],
+      {},
+      {},
+      stopIndex(
+        stop("910GNRCH", "NRW", 1),
+        stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+        stop("910GDISS", "DIS", 1),
+        stop("9100DISS1", "DIS", 0, "910GDISS")
+      )
+    );
+
+    expect(timetable.routeTrips[0][0].stopTimes.map(s => s.platformStop))
+      .toEqual(["9100NRCH4", "9100DISS1"]);
+  });
+
+  it("walks up through every level of grouping", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4A", null, 1000), st("910GDISS", 1030, null))],
+      {},
+      {},
+      stopIndex(
+        stop("910GNRCH", "NRW", 1),
+        stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+        stop("9100NRCH4A", "NRW", 4, "9100NRCH4"),
+        stop("910GDISS", "DIS", 1)
+      )
+    );
+
+    expect(timetable.stopIds).toEqual(["NRW", "DIS"]);
+  });
+
+  it("falls back to the id of a stop with no code", () => {
+    const timetable = createTimetable(
+      [t(st("NRW", null, 1000), st("DIS", 1030, null))],
+      {},
+      {},
+      stopIndex(stop("NRW", undefined), stop("DIS", undefined))
+    );
+
+    expect(timetable.stopIds).toEqual(["NRW", "DIS"]);
+  });
+
+  it("stops walking rather than following a parent that is not in the feed", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4", null, 1000), st("910GDISS", 1030, null))],
+      {},
+      {},
+      stopIndex(stop("9100NRCH4", "NRW", 0, "910GNRCH"), stop("910GDISS", "DIS", 1))
+    );
+
+    expect(timetable.stopIds).toEqual(["NRW", "DIS"]);
+  });
+
+  it("rejects two stations sharing a code, which would plan them as one place", () => {
+    const stops = stopIndex(stop("910GNRCH", "NRW", 1), stop("910GNRWICH", "NRW", 1));
+
+    expect(() => createTimetable([], {}, {}, stops))
+      .toThrow(/910GNRCH and 910GNRWICH both have the stop_code NRW/);
+  });
+
+  it("allows the platforms of a station to share its code", () => {
+    const stops = stopIndex(
+      stop("910GNRCH", "NRW", 1),
+      stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+      stop("9100NRCH5", "NRW", 0, "910GNRCH")
+    );
+
+    expect(() => createTimetable([], {}, {}, stops)).not.toThrow();
+  });
+
+  it("keeps only the calls a passenger can use, and the rest as allStopTimes", () => {
+    const passing = st("PAS", 1015, 1015);
+    passing.pickUp = false;
+    passing.dropOff = false;
+
+    const timetable = createTimetable(
+      [t(st("NRW", null, 1000), passing, st("DIS", 1030, null))],
+      {},
+      {},
+      {}
+    );
+
+    expect(timetable.stopIds).toEqual(["NRW", "DIS"]);
+    expect(timetable.routeTrips[0][0].allStopTimes?.map(s => s.stop)).toEqual(["NRW", "PAS", "DIS"]);
+  });
+
+  it("drops a trip that cannot be both boarded and alighted", () => {
+    const timetable = createTimetable(
+      [t(st("NRW", null, 1000), st("DIS", 1030, null)), t(st("NRW", null, 1000))],
+      {},
+      {},
+      {}
+    );
+
+    expect(timetable.routeTrips.length).toBe(1);
+    expect(timetable.routeTrips[0].length).toBe(1);
+  });
+
+  it("moves transfers and interchange onto the station", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4", null, 1000), st("910GDISS", 1030, null))],
+      { "9100NRCH4": [tf("9100NRCH4", "910GDISS", 300)] },
+      { "910GNRCH": 600 },
+      stopIndex(
+        stop("910GNRCH", "NRW", 1),
+        stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+        stop("910GDISS", "DIS", 1)
+      )
+    );
+
+    const from = timetable.stopIndex.get("NRW") as number;
+
+    expect(timetable.interchange[from]).toBe(600);
+    expect(timetable.transfers[from][0].destination).toBe(timetable.stopIndex.get("DIS"));
+  });
+
+  it("drops a transfer between two platforms of one station", () => {
+    const timetable = createTimetable(
+      [t(st("9100NRCH4", null, 1000), st("910GDISS", 1030, null))],
+      { "9100NRCH4": [tf("9100NRCH4", "9100NRCH5", 300)] },
+      {},
+      stopIndex(
+        stop("910GNRCH", "NRW", 1),
+        stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+        stop("9100NRCH5", "NRW", 0, "910GNRCH"),
+        stop("910GDISS", "DIS", 1)
+      )
+    );
+
+    expect(timetable.transfers[timetable.stopIndex.get("NRW") as number]).toEqual([]);
+  });
+
+  it("gives the same result when the same trips are used twice", () => {
+    const trips = [t(st("9100NRCH4", null, 1000), st("9100DISS1", 1030, null))];
+    const stops = stopIndex(
+      stop("910GNRCH", "NRW", 1),
+      stop("9100NRCH4", "NRW", 0, "910GNRCH"),
+      stop("910GDISS", "DIS", 1),
+      stop("9100DISS1", "DIS", 0, "910GDISS")
+    );
+
+    const once = createTimetable(trips, {}, {}, stops);
+    const twice = createTimetable(trips, {}, {}, stops);
+
+    expect(twice.stopIds).toEqual(once.stopIds);
+    expect(twice.routeTrips[0][0].stopTimes.map(s => s.platformStop))
+      .toEqual(["9100NRCH4", "9100DISS1"]);
   });
 
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -33,6 +33,7 @@ export function t(...stopTimes: StopTime[]): Trip {
 export function st(stop: StopID, arrivalTime: Time | null, departureTime: Time | null): StopTime {
   return {
     stop: stop,
+    platformStop: stop,
     arrivalTime: arrivalTime || departureTime!,
     departureTime: departureTime || arrivalTime!,
     dropOff: arrivalTime !== null,


### PR DESCRIPTION
Prepares raptor for the GTFS feed change: `stop_times` identify platforms (TIPLOC + platform), grouped under parent stations carrying the CRS.

Journeys are planned between stations, because that is where interchange time and transfers are defined and the only place a change of train is possible. Platforms and passing points are kept for display.

## Where it happens

Resolving stops to stations is part of setting up the algorithm's data structures, not part of reading the feed. `loadGTFS` returns stops as the feed gives them; `toStations` puts them into the terms the algorithm plans in, and `RaptorAlgorithmFactory.create` calls it when given the stop index.

```ts
const [trips, transfers, interchange, stops] = await loadGTFS(stream);
const raptor = RaptorAlgorithmFactory.create(trips, transfers, interchange, stops);
```

`toStations` is exported for anyone driving `createTimetable` directly. It rewrites the trips in place and running it twice is a no-op.

## The rule

**Every stop resolves to its station**, following `parent_station` up through however many levels of grouping the feed uses.

**Stations are identified by `stop_code`**, falling back to `stop_id` where there isn't one. That is what queries take and journeys come back in. A feed that identifies platforms has to give its stations ids of its own — `910GNRCH` — and puts the code the station is actually known by in `stop_code`. GTFS places no uniqueness requirement on `stop_code`, so two stations sharing one is rejected rather than silently planned as the same place:

```
Stops 910GNRCH and 910GNRWICH both have the stop_code NRW, which identifies the station
```

Platforms sharing their station's code is fine — only stations compete for a name.

**Calls that neither pick up nor set down are filtered** out of what the algorithm plans with. They cannot be used, and they lengthen routes and fragment them.

Nothing is lost: each stop time keeps the feed's `stop_id` as `platformStop`, each trip keeps its full pattern as `allStopTimes`, and `getFullStopTimes(leg)` expands a leg back to that pattern.

## Why it matters

Without the collapse the new feed does not merely perform worse — it throws, because `910GNRCH` is not in the stop space at all. Only `9100NRCH4`-style platform stops are.

|                 | platform stops | stations |
|-----------------|---------------:|---------:|
| stops           |          6,545 |    2,827 |
| routes          |         54,508 |   18,445 |
| route positions |        637,613 |  205,394 |

Routes drop 66%. Trips per route go from 5.1 to 15.1, which is the condition `RouteScanner`'s per-route scan position cache depends on. Platform stops would also need **27,490 platform-to-platform transfer edges** before a change of train was findable at all — three times the entire current footpath network. Leeds alone is 55 platform stops.

Against the old CRS feed the result is the same shape: 2,839 stops, 19,081 routes.

## Verification

Replanning against the old feed gives **byte-identical journeys**, bar 8 degenerate trips now dropped for having fewer than two calling points.

On the new feed the cross-platform change works, which is the point of the change:

```
NUN>LIV  NUN-CRE-LIV
   NUN/2 ATH TAM/1 LTV/1 RGL/2 STA/3 CRE/11
   CRE/6 RUN/2 LPY/2 MSH/2 LIV/6
```

Arrives platform 11, departs platform 6, interchange applied. Under platform-level stops that change is invisible.

## Breaking changes

- `RaptorAlgorithmFactory.create` takes the stop index as its fourth argument, before the optional date. TypeScript catches the two call sites in this repo that passed a date there; JavaScript callers will not get a compile error.
- Stop times are keyed by station `stop_code`. **The old feed puts the TIPLOC in `stop_code`**, so it now keys on TIPLOC (`NNTN` rather than `NUN`) — correct per this rule, and the old feed being the thing that is wrong, but it is a behaviour change for that feed.
- `Trip` gains `allStopTimes`; `StopTime` gains `platformStop`; `Stop` gains `locationType`, `parentStation` and `platformCode`. All optional, so hand-built trips are unaffected.

Worth a major version.

## Also

- `overtakes` compares against a running max rather than scanning every trip on the route, which was quadratic in trips per route — and this change puts more trips on each route.
- Station ids are interned from the stop index rather than held per row.
- `transfer-patterns.ts` filters to stations; it would otherwise fan out per platform for identical results.

## Not covered

The feed emits only 0.83% passing points, so `allStopTimes` is nearly identical to `stopTimes` today. Modelling the CIF directly suggests a complete feed would be ~42% passing points, at which point the calling-point filter is worth ~3x on scan work rather than the ~3% it saves now. The plumbing is in place for when the generator emits them.

https://claude.ai/code/session_01SNukVhJ15ygSNPs3iNf5Sf