### PR TITLE
Check the calendar covers a date in TripCalendar

### DIFF
--- a/src/network/TripCalendar.ts
+++ b/src/network/TripCalendar.ts
@@ -1,4 +1,5 @@
 import type { DateNumber, Trip } from "../gtfs/GTFS";
+import type { Network } from "./Network";
 import type { Service } from "../gtfs/Service";
 import { addDays, daysBetween, getDateNumber, getDayOfWeek } from "../query/DateUtil";
 
@@ -93,6 +94,19 @@ export function dayOffset(calendar: TripCalendar, date: DateNumber): number {
  * Returned by dayOffset for a date outside the period the calendar covers
  */
 export const NOT_COVERED = -1;
+
+/**
+ * Reject a date the timetable has no calendar for, rather than quietly finding nothing
+ */
+export function checkCovered(network: Network, date: DateNumber): void {
+  const { calendar } = network.timetable.routes;
+
+  if (dayOffset(calendar, date) === NOT_COVERED) {
+    const { startDate, endDate } = calendar;
+
+    throw new Error(`The timetable covers ${startDate} to ${endDate}, so it cannot plan for ${date}`);
+  }
+}
 
 export interface TripCalendar {
   /** First date the calendar covers */

--- a/src/query/DateUtil.ts
+++ b/src/query/DateUtil.ts
@@ -1,5 +1,4 @@
 import type { DateNumber, DayOfWeek } from "../gtfs/GTFS";
-import type { RaptorAlgorithm } from "../raptor/RaptorAlgorithm";
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -36,15 +35,4 @@ export function getDayOfWeek(date: DateNumber): DayOfWeek {
 // UTC throughout so that a clock change never moves a date onto the day either side of it
 function toTimestamp(date: DateNumber): number {
   return Date.UTC(Math.floor(date / 10000), Math.floor(date / 100) % 100 - 1, date % 100);
-}
-
-/**
- * Reject a date the timetable has no calendar for, rather than quietly finding nothing
- */
-export function checkCovered(raptor: RaptorAlgorithm, date: DateNumber): void {
-  if (!raptor.covers(date)) {
-    const [start, end] = raptor.period;
-
-    throw new Error(`The timetable covers ${start} to ${end}, so it cannot plan for ${date}`);
-  }
 }

--- a/src/query/GroupStationDepartAfterQuery.ts
+++ b/src/query/GroupStationDepartAfterQuery.ts
@@ -3,7 +3,8 @@ import { type Origins, RaptorAlgorithm } from "../raptor/RaptorAlgorithm";
 import type { StopID, Time } from "../gtfs/GTFS";
 import type { Network } from "../network/Network";
 import type { ResultsFactory } from "../results/ResultsFactory";
-import { checkCovered, getDateNumber } from "./DateUtil";
+import { checkCovered } from "../network/TripCalendar";
+import { getDateNumber } from "./DateUtil";
 import type { Journey } from "../results/Journey";
 import type { JourneyFilter } from "../results/filter/JourneyFilter";
 import { NOT_REACHED, type StopIdx } from "../network/Timetable";
@@ -31,7 +32,7 @@ export class GroupStationDepartAfterQuery {
    * Plan a journey between the origin and destination set of stops on the given date and time
    */
   public plan(origins: StopID[], destinations: StopID[], date: Date, time: Time): Journey[] {
-    checkCovered(this.raptor, getDateNumber(date));
+    checkCovered(this.network, getDateNumber(date));
 
     // the algorithm works in stop indexes, the query in the ids the caller knows
     const originTimes: Origins = new Map(this.toStopIndexes(origins).map(stop => [stop, time]));

--- a/src/query/TransferPatternQuery.ts
+++ b/src/query/TransferPatternQuery.ts
@@ -1,7 +1,8 @@
 import { RaptorAlgorithm } from "../raptor/RaptorAlgorithm";
 import type { Network } from "../network/Network";
 import type { StopID } from "../gtfs/GTFS";
-import { checkCovered, getDateNumber } from "./DateUtil";
+import { checkCovered } from "../network/TripCalendar";
+import { getDateNumber } from "./DateUtil";
 import type { StringResults, TransferPatternIndex } from "../transfer-pattern/results/StringResults";
 
 /**
@@ -26,7 +27,7 @@ export class TransferPatternQuery {
     const date = getDateNumber(dateObj);
     const results = this.resultFactory();
 
-    checkCovered(this.raptor, date);
+    checkCovered(this.network, date);
 
     const stop = this.network.stopIndex.get(origin);
 

--- a/src/raptor/RaptorAlgorithm.ts
+++ b/src/raptor/RaptorAlgorithm.ts
@@ -1,6 +1,5 @@
 import type { ConnectionIndex } from "./Connection";
-import type { DateNumber, StopID, Time, Transfer } from "../gtfs/GTFS";
-import { dayOffset, NOT_COVERED } from "../network/TripCalendar";
+import type { DateNumber, Time } from "../gtfs/GTFS";
 import { buildQueue } from "./Queue";
 import { NO_TRIP, RouteScanner } from "./RouteScanner";
 import { type Arrivals, ScanResults } from "./ScanResults";
@@ -14,23 +13,6 @@ export class RaptorAlgorithm {
   constructor(
     private readonly timetable: Timetable
   ) { }
-
-  /**
-   * Whether the timetable was built with a calendar reaching the given date. Planning for a date
-   * it does not cover finds nothing, so queries check before they scan.
-   */
-  public covers(date: DateNumber): boolean {
-    return dayOffset(this.timetable.routes.calendar, date) !== NOT_COVERED;
-  }
-
-  /**
-   * The period the timetable covers
-   */
-  public get period(): [DateNumber, DateNumber] {
-    const { startDate, endDate } = this.timetable.routes.calendar;
-
-    return [startDate, endDate];
-  }
 
   /**
    * Perform a plan of the routes at a given time and return the resulting kConnections index

--- a/src/raptor/ScanResults.ts
+++ b/src/raptor/ScanResults.ts
@@ -1,6 +1,6 @@
 import type { Time } from "../gtfs/GTFS";
 import type { Origins } from "./RaptorAlgorithm";
-import type { Connection, ConnectionIndex, TransferIdx } from "./Connection";
+import type { ConnectionIndex, TransferIdx } from "./Connection";
 import { NOT_REACHED, type RouteIdx, type StopIdx } from "../network/Timetable";
 
 /**


### PR DESCRIPTION
`RaptorAlgorithm` exposed `covers()` and a `period` getter purely so `checkCovered` could ask whether a query's date was in range. Both just read `timetable.routes.calendar`, so the check now lives in `TripCalendar` next to `dayOffset` and `NOT_COVERED`, and takes the `Network`.

- `RaptorAlgorithm` loses `covers()` and `period` — it is back to scanning
- `checkCovered` moves out of `DateUtil`, which is pure date arithmetic again with no network imports
- `GroupStationDepartAfterQuery` and `TransferPatternQuery` pass `this.network`

Error message and behaviour are unchanged, so the existing tests cover it.

Last commit also removes imports an earlier refactor left unused in `RaptorAlgorithm` and `ScanResults`.

`tsc --noEmit`, biome and the 93 tests all pass.

https://claude.ai/code/session_014j8ShewMFQpToahWTdDZ19