### PR TITLE
Give the scan a cursor over the route it is scanning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./query/TransferPatternQuery";
 export * from "./query/GroupStationDepartAfterQuery";
 export * from "./raptor/Queue";
 export * from "./raptor/RaptorAlgorithm";
+export * from "./raptor/RouteCursor";
 export * from "./raptor/RouteScanner";
 export * from "./raptor/ScanResults";
 export * from "./network/TripCalendar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export * from "./query/GroupStationDepartAfterQuery";
 export * from "./raptor/Queue";
 export * from "./raptor/RaptorAlgorithm";
 export * from "./raptor/RouteCursor";
-export * from "./raptor/RouteScanner";
+export * from "./raptor/TripScanner";
 export * from "./raptor/ScanResults";
 export * from "./network/TripCalendar";
 export * from "./network/Network";

--- a/src/raptor/RaptorAlgorithm.ts
+++ b/src/raptor/RaptorAlgorithm.ts
@@ -1,18 +1,25 @@
 import type { ConnectionIndex } from "./Connection";
 import type { DateNumber, Time } from "../gtfs/GTFS";
 import { buildQueue } from "./Queue";
+import { RouteCursor } from "./RouteCursor";
 import { NO_TRIP, RouteScanner } from "./RouteScanner";
 import { type Arrivals, ScanResults } from "./ScanResults";
-import { DROP_OFF, NOT_REACHED, PICK_UP, type StopIdx, type Timetable } from "../network/Timetable";
+import { NOT_REACHED, type StopIdx, type Timetable } from "../network/Timetable";
 
 /**
  * Implementation of the Raptor journey planning algorithm
  */
 export class RaptorAlgorithm {
+  /**
+   * Reused by every scan. A scan is synchronous, so there is never more than one route in flight.
+   */
+  private readonly routes: RouteCursor;
 
   constructor(
     private readonly timetable: Timetable
-  ) { }
+  ) {
+    this.routes = new RouteCursor(timetable.routes);
+  }
 
   /**
    * Perform a plan of the routes at a given time and return the resulting kConnections index
@@ -36,46 +43,29 @@ export class RaptorAlgorithm {
   }
 
   private scanRoutes(results: ScanResults, routeScanner: RouteScanner, markedStops: StopIdx[]): void {
-    const { interchange, routes } = this.timetable;
-    const { arrivals, flags, stopOffsets, stops, stopTimesBase, tripOffsets } = routes;
+    const { interchange } = this.timetable;
 
     for (const [route, startPosition] of buildQueue(this.timetable.routesByStop, markedStops)) {
-      const stopsBase = stopOffsets[route];
-      const numStops = stopOffsets[route + 1] - stopsBase;
-      const timesBase = stopTimesBase[route];
+      this.routes.moveTo(route);
 
       let boardingPoint = -1;
       let trip = NO_TRIP;
-      let tripBase = -1;
 
-      for (let pi = startPosition; pi < numStops; pi++) {
-        const stop = stops[stopsBase + pi];
+      for (let pi = startPosition; pi < this.routes.numStops; pi++) {
+        const stop = this.routes.stopAt(pi);
         const previousArrival = results.previousArrival(stop);
+        const arrival = trip === NO_TRIP ? NOT_REACHED : this.routes.arrival(trip, pi) + interchange[stop];
 
-        if (trip !== NO_TRIP) {
-          const arrival = arrivals[tripBase + pi] + interchange[stop];
-
-          if ((flags[stopsBase + pi] & DROP_OFF) !== 0 && arrival < results.bestArrival(stop)) {
-            results.setTrip(route, tripOffsets[route] + trip, boardingPoint, pi, stop, arrival);
-          }
-          // reaching the stop earlier by other means may make an earlier trip on this route
-          // catchable, but only where the route picks passengers up
-          else if ((flags[stopsBase + pi] & PICK_UP) !== 0 && previousArrival !== NOT_REACHED && previousArrival < arrival) {
-            const newTrip = routeScanner.getTrip(route, pi, previousArrival);
-
-            if (newTrip !== NO_TRIP) {
-              trip = newTrip;
-              tripBase = timesBase + newTrip * numStops;
-              boardingPoint = pi;
-            }
-          }
+        if (this.routes.canDropOff(pi) && arrival < results.bestArrival(stop)) {
+          results.setTrip(route, this.routes.globalTrip(trip), boardingPoint, pi, stop, arrival);
         }
-        else if ((flags[stopsBase + pi] & PICK_UP) !== 0 && previousArrival !== NOT_REACHED) {
-          const newTrip = routeScanner.getTrip(route, pi, previousArrival);
+        // reaching the stop earlier by other means may make an earlier trip on this route
+        // catchable, but only where the route picks passengers up
+        else if (this.routes.canPickUp(pi) && previousArrival !== NOT_REACHED && previousArrival < arrival) {
+          const newTrip = routeScanner.getTrip(this.routes, pi, previousArrival);
 
           if (newTrip !== NO_TRIP) {
             trip = newTrip;
-            tripBase = timesBase + newTrip * numStops;
             boardingPoint = pi;
           }
         }

--- a/src/raptor/RaptorAlgorithm.ts
+++ b/src/raptor/RaptorAlgorithm.ts
@@ -2,7 +2,7 @@ import type { ConnectionIndex } from "./Connection";
 import type { DateNumber, Time } from "../gtfs/GTFS";
 import { buildQueue } from "./Queue";
 import { RouteCursor } from "./RouteCursor";
-import { NO_TRIP, RouteScanner } from "./RouteScanner";
+import { NO_TRIP, TripScanner } from "./TripScanner";
 import { type Arrivals, ScanResults } from "./ScanResults";
 import { NOT_REACHED, type StopIdx, type Timetable } from "../network/Timetable";
 
@@ -25,7 +25,7 @@ export class RaptorAlgorithm {
    * Perform a plan of the routes at a given time and return the resulting kConnections index
    */
   public scan(origins: Origins, date: DateNumber): [ConnectionIndex, Arrivals] {
-    const routeScanner = new RouteScanner(this.timetable.routes, date);
+    const tripScanner = new TripScanner(this.timetable.routes, date);
     const results = new ScanResults(this.timetable.interchange.length, origins);
 
     let markedStops = [...origins.keys()];
@@ -33,7 +33,7 @@ export class RaptorAlgorithm {
     while (markedStops.length > 0) {
       results.addRound();
 
-      this.scanRoutes(results, routeScanner, markedStops);
+      this.scanRoutes(results, tripScanner, markedStops);
       this.scanTransfers(results, markedStops);
 
       markedStops = results.getMarkedStops();
@@ -42,7 +42,7 @@ export class RaptorAlgorithm {
     return results.finalize();
   }
 
-  private scanRoutes(results: ScanResults, routeScanner: RouteScanner, markedStops: StopIdx[]): void {
+  private scanRoutes(results: ScanResults, tripScanner: TripScanner, markedStops: StopIdx[]): void {
     const { interchange } = this.timetable;
 
     for (const [route, startPosition] of buildQueue(this.timetable.routesByStop, markedStops)) {
@@ -62,7 +62,7 @@ export class RaptorAlgorithm {
         // reaching the stop earlier by other means may make an earlier trip on this route
         // catchable, but only where the route picks passengers up
         else if (this.routes.canPickUp(pi) && previousArrival !== NOT_REACHED && previousArrival < arrival) {
-          const newTrip = routeScanner.getTrip(this.routes, pi, previousArrival);
+          const newTrip = tripScanner.earliestTrip(this.routes, pi, previousArrival);
 
           if (newTrip !== NO_TRIP) {
             trip = newTrip;

--- a/src/raptor/RouteCursor.ts
+++ b/src/raptor/RouteCursor.ts
@@ -1,0 +1,80 @@
+import type { Time } from "../gtfs/GTFS";
+import { DROP_OFF, PICK_UP, type RouteIdx, type Routes, type StopIdx } from "../network/Timetable";
+
+/**
+ * A view positioned on one route, holding the offsets its slices start at so that the scan works
+ * in positions and trip numbers local to the route rather than indexes into the global arrays.
+ *
+ * It is a view, not a copy: every accessor reads through to the timetable. Resolving the offsets
+ * costs three loads, so it is done once per route in `moveTo` rather than once per stop, which is
+ * also why a cursor is reused across routes instead of being allocated for each one.
+ */
+export class RouteCursor {
+  private atRoute = -1;
+  private stopsBase = 0;
+  private timesBase = 0;
+  private firstTrip = 0;
+  private stopsInRoute = 0;
+
+  constructor(private readonly routes: Routes) { }
+
+  /**
+   * The route the cursor is positioned on
+   */
+  public get route(): RouteIdx {
+    return this.atRoute;
+  }
+
+  /**
+   * Number of stops on the route, which is also the stride of its arrivals and departures
+   */
+  public get numStops(): number {
+    return this.stopsInRoute;
+  }
+
+  /**
+   * Position the cursor on a route, resolving where its slice of each global array starts.
+   */
+  public moveTo(route: RouteIdx): void {
+    const { stopOffsets, stopTimesBase, tripOffsets } = this.routes;
+
+    this.atRoute = route;
+    this.stopsBase = stopOffsets[route];
+    this.stopsInRoute = stopOffsets[route + 1] - this.stopsBase;
+    this.timesBase = stopTimesBase[route];
+    this.firstTrip = tripOffsets[route];
+  }
+
+  public stopAt(position: number): StopIdx {
+    return this.routes.stops[this.stopsBase + position];
+  }
+
+  /**
+   * Whether the route takes passengers on at the given position
+   */
+  public canPickUp(position: number): boolean {
+    return (this.routes.flags[this.stopsBase + position] & PICK_UP) !== 0;
+  }
+
+  /**
+   * Whether the route sets passengers down at the given position
+   */
+  public canDropOff(position: number): boolean {
+    return (this.routes.flags[this.stopsBase + position] & DROP_OFF) !== 0;
+  }
+
+  public arrival(trip: number, position: number): Time {
+    return this.routes.arrivals[this.timesBase + trip * this.stopsInRoute + position];
+  }
+
+  public departure(trip: number, position: number): Time {
+    return this.routes.departures[this.timesBase + trip * this.stopsInRoute + position];
+  }
+
+  /**
+   * The route's nth trip in the global, route major numbering the calendar is bit packed in
+   */
+  public globalTrip(trip: number): number {
+    return this.firstTrip + trip;
+  }
+}

--- a/src/raptor/RouteScanner.ts
+++ b/src/raptor/RouteScanner.ts
@@ -1,6 +1,7 @@
 import type { DateNumber, Time } from "../gtfs/GTFS";
 import { dayOffset, NOT_COVERED } from "../network/TripCalendar";
-import type { RouteIdx, Routes } from "../network/Timetable";
+import type { RouteCursor } from "./RouteCursor";
+import type { Routes } from "../network/Timetable";
 
 /**
  * No trip on the route is reachable.
@@ -17,7 +18,7 @@ export class RouteScanner {
   /** The calendar's slice for the date being scanned, or an empty one outside the period it covers */
   private readonly runsToday: Uint8Array;
 
-  constructor(private readonly routes: Routes, date: DateNumber) {
+  constructor(routes: Routes, date: DateNumber) {
     const calendar = routes.calendar;
     const offset = dayOffset(calendar, date);
 
@@ -31,14 +32,11 @@ export class RouteScanner {
   }
 
   /**
-   * Return the index of the earliest trip on the route that can be boarded at the given position,
-   * or NO_TRIP if there isn't one.
+   * Return the index of the earliest trip on the route the cursor is positioned on that can be
+   * boarded at the given position, or NO_TRIP if there isn't one.
    */
-  public getTrip(route: RouteIdx, position: number, time: Time): number {
-    const { departures, stopOffsets, stopTimesBase, tripOffsets } = this.routes;
-    const numStops = stopOffsets[route + 1] - stopOffsets[route];
-    const firstTrip = tripOffsets[route];
-    const base = stopTimesBase[route] + position;
+  public getTrip(cursor: RouteCursor, position: number, time: Time): number {
+    const route = cursor.route;
     const runsToday = this.runsToday;
 
     let lastFound = NO_TRIP;
@@ -46,11 +44,11 @@ export class RouteScanner {
     // iterate backwards through the trips on the route, starting where we last found a trip
     for (let i = this.routeScanPosition[route]; i >= 0; i--) {
       // if the trip is unreachable, exit the loop
-      if (departures[base + i * numStops] < time) {
+      if (cursor.departure(i, position) < time) {
         break;
       }
       // if it is reachable and the trip is running that day, update the last valid trip found
-      const trip = firstTrip + i;
+      const trip = cursor.globalTrip(i);
 
       if ((runsToday[trip >> 3] & (1 << (trip & 7))) !== 0) {
         lastFound = i;

--- a/src/raptor/TripScanner.ts
+++ b/src/raptor/TripScanner.ts
@@ -9,12 +9,12 @@ import type { Routes } from "../network/Timetable";
 export const NO_TRIP = -1;
 
 /**
- * Returns trips for specific routes. Maintains the position of the last trip returned in order to
- * reduce plan time.
+ * Finds the trip to board on a route, for one date. Maintains the position of the last trip
+ * returned in order to reduce plan time.
  */
-export class RouteScanner {
+export class TripScanner {
   /** Trip each route is scanned back from, starting at its last trip and only ever moving earlier */
-  private readonly routeScanPosition: Int32Array;
+  private readonly scanPosition: Int32Array;
   /** The calendar's slice for the date being scanned, or an empty one outside the period it covers */
   private readonly runsToday: Uint8Array;
 
@@ -22,7 +22,7 @@ export class RouteScanner {
     const calendar = routes.calendar;
     const offset = dayOffset(calendar, date);
 
-    this.routeScanPosition = Int32Array.from(
+    this.scanPosition = Int32Array.from(
       { length: routes.tripOffsets.length - 1 },
       (_, route) => routes.tripOffsets[route + 1] - routes.tripOffsets[route] - 1
     );
@@ -35,14 +35,14 @@ export class RouteScanner {
    * Return the index of the earliest trip on the route the cursor is positioned on that can be
    * boarded at the given position, or NO_TRIP if there isn't one.
    */
-  public getTrip(cursor: RouteCursor, position: number, time: Time): number {
+  public earliestTrip(cursor: RouteCursor, position: number, time: Time): number {
     const route = cursor.route;
     const runsToday = this.runsToday;
 
     let lastFound = NO_TRIP;
 
     // iterate backwards through the trips on the route, starting where we last found a trip
-    for (let i = this.routeScanPosition[route]; i >= 0; i--) {
+    for (let i = this.scanPosition[route]; i >= 0; i--) {
       // if the trip is unreachable, exit the loop
       if (cursor.departure(i, position) < time) {
         break;
@@ -59,7 +59,7 @@ export class RouteScanner {
       // as there may be some services that are reachable but not running before the last found service and searching
       // must continue from the last reachable point.
       if (lastFound === NO_TRIP || lastFound === i) {
-        this.routeScanPosition[route] = i;
+        this.scanPosition[route] = i;
       }
     }
 

--- a/test/unit/query/RangeQuery.spec.ts
+++ b/test/unit/query/RangeQuery.spec.ts
@@ -65,7 +65,7 @@ describe("RangeQuery", () => {
    *
    * That is rejected because it does not improve the earliest arrival time at C
    */
-  it("does not share bestArrivals or routeScanner", () => {
+  it("does not share bestArrivals or tripScanner", () => {
     const trips = [
       t(
         st("A", null, 1359),


### PR DESCRIPTION
Two commits.

**Give the scan a cursor over the route it is scanning.** `scanRoutes` and
`getTrip` each resolved the same three offsets by hand, and the trip major index
into `arrivals` and `departures` was spelled out in four places, where getting a
term wrong reads another trip's times rather than failing. `RouteCursor` is
positioned on a route by `moveTo` and answers in positions and trip numbers
local to it. It is a view rather than a copy, reused across routes.

`getTrip` takes the cursor `scanRoutes` has already positioned, so it no longer
recomputes those offsets per call and no longer reads the routes at all. The two
branches that boarded a trip collapse into one by defaulting the arrival to
`NOT_REACHED` when no trip is held.

**Name the trip scanner after the trips it scans.** `RouteScanner` sat next to
the new `RouteCursor` and the two read as variants of each other. Only the
cursor is about routes. It becomes `TripScanner`, and `getTrip` becomes
`earliestTrip`.

Breaking: `RouteScanner` is renamed in the public API. `RouteCursor` is exported
since it appears in `earliestTrip`'s signature.

Planning the standard set of queries against gb-rail is unchanged. Measured
against `npm run perf` over interleaved runs; the difference sits inside that
harness's noise, which is wide because it times a single cold pass per process.

https://claude.ai/code/session_01FwLy8S46u3n8Dp4d8J5MYn