### PR TITLE
Plan the trip a passenger stays on across a coupling

### DIFF
--- a/src/gtfs/EntityType.ts
+++ b/src/gtfs/EntityType.ts
@@ -38,7 +38,10 @@ export const COLUMNS: Record<EntityType, readonly string[]> = {
   calendar_date: ["service_id", "date", "exception_type"],
   trip: ["trip_id", "service_id"],
   stop_time: ["trip_id", "arrival_time", "departure_time", "stop_id", "pickup_type", "drop_off_type"],
-  transfer: ["from_stop_id", "to_stop_id", "min_transfer_time", "start_time", "end_time"],
+  transfer: [
+    "from_stop_id", "to_stop_id", "from_trip_id", "to_trip_id",
+    "transfer_type", "min_transfer_time", "start_time", "end_time"
+  ],
   feed_info: ["feed_start_date", "feed_end_date", "feed_version"],
   stop: [
     "stop_id", "stop_code", "stop_name", "stop_desc", "stop_lat", "stop_lon",

--- a/src/gtfs/FeedBuilder.ts
+++ b/src/gtfs/FeedBuilder.ts
@@ -1,4 +1,4 @@
-import type { CalendarIndex, DateIndex, Interchange, StopIndex, TransfersByOrigin, Trip } from "./GTFS.js";
+import type { CalendarIndex, DateIndex, Interchange, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
 import type { EntityType } from "./EntityType.js";
 import type { Row } from "./CSVParser.js";
 import type { FeedInfo, GTFSFeed } from "./GTFSLoader.js";
@@ -17,6 +17,7 @@ export class FeedBuilder {
   private readonly timeParser = new TimeParser();
   private readonly trips: Trip[] = [];
   private readonly transfers: TransfersByOrigin = {};
+  private readonly links: TripLink[] = [];
   private readonly interchange: Interchange = {};
   private readonly calendars: CalendarIndex = {};
   private readonly dates: Record<string, DateIndex> = {};
@@ -64,6 +65,7 @@ export class FeedBuilder {
     return {
       trips: this.trips,
       transfers: this.transfers,
+      links: this.links,
       interchange: this.interchange,
       stops: this.stops,
       feedInfo: this.feedInfo
@@ -94,12 +96,33 @@ export class FeedBuilder {
   }
 
   private addTransfer(row: Row): void {
-    this.footpath(
-      row,
-      +(row.min_transfer_time as string),
-      row.start_time ? this.timeParser.getTime(row.start_time) : 0,
-      row.end_time ? this.timeParser.getTime(row.end_time) : Number.MAX_SAFE_INTEGER
-    );
+    // 3 forbids a change and 5 requires re-boarding, which is what happens with no row at all
+    if (row.transfer_type === "3" || row.transfer_type === "5") {
+      return;
+    }
+
+    if (row.transfer_type === "4") {
+      this.addLink(row);
+    }
+    else {
+      this.footpath(
+        row,
+        +(row.min_transfer_time as string),
+        row.start_time ? this.timeParser.getTime(row.start_time) : 0,
+        row.end_time ? this.timeParser.getTime(row.end_time) : Number.MAX_SAFE_INTEGER
+      );
+    }
+  }
+
+  private addLink(row: Row): void {
+    if (row.from_trip_id && row.to_trip_id) {
+      this.links.push({
+        fromTripId: this.intern(row.from_trip_id),
+        toTripId: this.intern(row.to_trip_id),
+        fromStop: row.from_stop_id === undefined ? undefined : this.intern(row.from_stop_id),
+        toStop: row.to_stop_id === undefined ? undefined : this.intern(row.to_stop_id)
+      });
+    }
   }
 
   /**

--- a/src/gtfs/GTFS.ts
+++ b/src/gtfs/GTFS.ts
@@ -1,7 +1,7 @@
 /**
  * StopID e.g. NRW
  */
-import type { Service } from "./Service.js";
+import type { ServiceCalendar } from "./Service.js";
 
 export type StopID = string;
 
@@ -59,7 +59,20 @@ export interface Trip {
   /** The trip's stopping pattern as the feed gives it, passing points and all */
   stopTimes: StopTime[];
   serviceId: ServiceID;
-  service: Service;
+  service: ServiceCalendar;
+}
+
+/**
+ * A transfers.txt row of transfer_type 4, saying the vehicle of one trip carries on as another.
+ *
+ * The stops are optional in GTFS and identify platforms rather than the station the coupling
+ * happens at, so they place the coupling within each trip rather than name where it is.
+ */
+export interface TripLink {
+  fromTripId: TripID;
+  toTripId: TripID;
+  fromStop?: StopID;
+  toStop?: StopID;
 }
 
 /**

--- a/src/gtfs/GTFSLoader.ts
+++ b/src/gtfs/GTFSLoader.ts
@@ -1,4 +1,4 @@
-import type { DateNumber, Interchange, StopIndex, TransfersByOrigin, Trip } from "./GTFS.js";
+import type { DateNumber, Interchange, StopIndex, TransfersByOrigin, Trip, TripLink } from "./GTFS.js";
 import { COLUMNS, entityTypeOf } from "./EntityType.js";
 import { CSVParser } from "./CSVParser.js";
 import { FeedBuilder } from "./FeedBuilder.js";
@@ -149,6 +149,8 @@ function describe(url: string, status: number | undefined, cause: unknown): stri
 export interface GTFSFeed {
   trips: Trip[];
   transfers: TransfersByOrigin;
+  /** Couplings between trips, which the timetable turns into the trips a passenger stays on */
+  links: TripLink[];
   interchange: Interchange;
   stops: StopIndex;
   /** feed_info.txt, which a feed does not have to provide */

--- a/src/gtfs/LinkedTrips.ts
+++ b/src/gtfs/LinkedTrips.ts
@@ -1,0 +1,171 @@
+import type { StopID, StopTime, Trip, TripID, TripLink } from "./GTFS.js";
+import { LinkedService, type ServiceCalendar } from "./Service.js";
+
+const SECONDS_IN_DAY = 86400;
+
+/**
+ * The trips a passenger can stay on across a coupling, one per link.
+ *
+ * A link says a vehicle carries on as another trip, so staying on it is a trip in its own right:
+ * the arriving trip's calls up to the coupling, then the departing trip's. The two trips are left
+ * as they are and the through trip is added alongside them, because each still runs alone on the
+ * days the other does not, and each is still boarded by passengers who really do change.
+ *
+ * A trip tells its times in its own service day, so a portion leaving after midnight departs
+ * earlier in the day than the trip it continues arrived. It is moved onto the arriving trip's day,
+ * forwards only, so that the through trip reads from its first call however the feed dated it.
+ */
+export function linkTrips(
+  trips: Trip[],
+  links: TripLink[],
+  station: (stop: StopID) => StopID
+): Trip[] {
+  if (links.length === 0) {
+    return [];
+  }
+
+  const byId = index(trips, links);
+  const dayEarlier = new Map<ServiceCalendar, ServiceCalendar>();
+  const linked: Trip[] = [];
+
+  for (const link of links) {
+    const from = byId.get(link.fromTripId);
+    const to = byId.get(link.toTripId);
+
+    if (from === undefined || to === undefined) {
+      continue;
+    }
+
+    const alights = indexOfStop(from.stopTimes, link.fromStop, station, true);
+    const boards = indexOfStop(to.stopTimes, link.toStop, station, false);
+
+    if (alights === -1 || boards === -1) {
+      continue;
+    }
+
+    const arrival = from.stopTimes[alights].arrivalTime;
+    const departure = to.stopTimes[boards].departureTime;
+    const shift = departure < arrival ? SECONDS_IN_DAY : 0;
+
+    // a coupling more than a day apart is not one a day's shift can put in order
+    if (departure + shift < arrival) {
+      continue;
+    }
+
+    linked.push({
+      tripId: `${from.tripId}_${to.tripId}`,
+      serviceId: `${from.serviceId}_${to.serviceId}`,
+      stopTimes: join(from.stopTimes, alights, to.stopTimes, boards, shift),
+      service: new LinkedService(from.service, shift === 0 ? to.service : earlier(dayEarlier, to.service))
+    });
+  }
+
+  return linked;
+}
+
+/**
+ * Every trip a link names.
+ *
+ * Planning for a single date keeps only the trips running on it, and a portion leaving after
+ * midnight runs on the day after the trip it continues, so the coupled trips are kept whatever date
+ * is planned for. The calendar still decides which of them can be boarded.
+ */
+export function coupledTripIds(links: TripLink[]): Set<TripID> {
+  const ids = new Set<TripID>();
+
+  for (const link of links) {
+    ids.add(link.fromTripId);
+    ids.add(link.toTripId);
+  }
+
+  return ids;
+}
+
+/**
+ * The trips the links name. Only a few thousand trips of a feed's hundreds of thousands are coupled,
+ * so they are picked out rather than all of them indexed.
+ */
+function index(trips: Trip[], links: TripLink[]): Map<TripID, Trip> {
+  const wanted = coupledTripIds(links);
+  const byId = new Map<TripID, Trip>();
+
+  for (const trip of trips) {
+    if (wanted.has(trip.tripId)) {
+      byId.set(trip.tripId, trip);
+    }
+  }
+
+  return byId;
+}
+
+/**
+ * The two trips' calls as one, sharing a single call at the coupling: the passenger arrives on the
+ * first trip and leaves on the second, so that call is set down by one and picked up by the other.
+ */
+function join(
+  from: StopTime[],
+  alights: number,
+  to: StopTime[],
+  boards: number,
+  shift: number
+): StopTime[] {
+  const stopTimes = from.slice(0, alights);
+
+  stopTimes.push({
+    ...from[alights],
+    departureTime: to[boards].departureTime + shift,
+    pickUp: to[boards].pickUp
+  });
+
+  for (let i = boards + 1; i < to.length; i++) {
+    stopTimes.push(shift === 0 ? to[i] : {
+      ...to[i],
+      arrivalTime: to[i].arrivalTime + shift,
+      departureTime: to[i].departureTime + shift
+    });
+  }
+
+  return stopTimes;
+}
+
+/**
+ * Where the coupling is within a trip: the last call there for the trip being left, the first for
+ * the one being joined, which is as far as the passenger rides one and as early as they board the
+ * other. A link that names no stop couples the trips end to end.
+ */
+function indexOfStop(
+  stopTimes: StopTime[],
+  stop: StopID | undefined,
+  station: (stop: StopID) => StopID,
+  last: boolean
+): number {
+  if (stop === undefined) {
+    return last ? stopTimes.length - 1 : 0;
+  }
+
+  const at = station(stop);
+
+  for (let i = 0; i < stopTimes.length; i++) {
+    const position = last ? stopTimes.length - 1 - i : i;
+
+    if (station(stopTimes[position].stop) === at) {
+      return position;
+    }
+  }
+
+  return -1;
+}
+
+function earlier(
+  cache: Map<ServiceCalendar, ServiceCalendar>,
+  service: ServiceCalendar
+): ServiceCalendar {
+  let shifted = cache.get(service);
+
+  if (shifted === undefined) {
+    shifted = service.dayEarlier();
+    cache.set(service, shifted);
+  }
+
+  return shifted;
+}

--- a/src/gtfs/Normalise.ts
+++ b/src/gtfs/Normalise.ts
@@ -1,5 +1,6 @@
 import type { Interchange, Stop, StopID, StopIndex, StopTime, Transfer, Trip } from "./GTFS.js";
 import type { GTFSFeed } from "./GTFSLoader.js";
+import { linkTrips } from "./LinkedTrips.js";
 
 /**
  * A feed may group stops under a station and those under a station in turn, so the walk up is
@@ -24,7 +25,7 @@ export function normalise(feed: GTFSFeed): TimetableInput {
   const trips: Trip[] = [];
   const calls: StopTime[][] = [];
 
-  for (const trip of feed.trips) {
+  const add = (trip: Trip): void => {
     const tripCalls = trip.stopTimes.filter(isCall);
 
     // a trip that cannot be both boarded and alighted is of no use
@@ -32,6 +33,14 @@ export function normalise(feed: GTFSFeed): TimetableInput {
       trips.push(trip);
       calls.push(tripCalls);
     }
+  };
+
+  for (const trip of feed.trips) {
+    add(trip);
+  }
+
+  for (const trip of linkTrips(feed.trips, feed.links, station)) {
+    add(trip);
   }
 
   const transfers: Transfer[] = [];

--- a/src/gtfs/Service.ts
+++ b/src/gtfs/Service.ts
@@ -1,6 +1,16 @@
 import type { DateIndex, DateNumber, DayOfWeek } from "./GTFS.js";
+import { addDays } from "../query/DateUtil.js";
 
-export class Service {
+/**
+ * The days a trip runs on.
+ */
+export interface ServiceCalendar {
+  runsOn(date: DateNumber, dow: DayOfWeek): boolean;
+  /** The same days told a day earlier, so "runs on the day after" can be asked as "runs on" */
+  dayEarlier(): ServiceCalendar;
+}
+
+export class Service implements ServiceCalendar {
 
   constructor(
     private readonly startDate: DateNumber,
@@ -16,5 +26,39 @@ export class Service {
       this.endDate >= date &&
       this.days[dow]
     );
+  }
+
+  public dayEarlier(): Service {
+    const days = {} as Record<DayOfWeek, boolean>;
+    const dates: DateIndex = {};
+
+    for (let day = 0; day < 7; day++) {
+      days[day as DayOfWeek] = this.days[((day + 1) % 7) as DayOfWeek];
+    }
+
+    for (const date of Object.keys(this.dates)) {
+      dates[addDays(+date, -1)] = this.dates[+date];
+    }
+
+    return new Service(addDays(this.startDate, -1), addDays(this.endDate, -1), days, dates);
+  }
+}
+
+/**
+ * A trip made of two coupled trips runs on the days both of them do.
+ */
+export class LinkedService implements ServiceCalendar {
+
+  constructor(
+    private readonly from: ServiceCalendar,
+    private readonly to: ServiceCalendar
+  ) {}
+
+  public runsOn(date: DateNumber, dow: DayOfWeek): boolean {
+    return this.from.runsOn(date, dow) && this.to.runsOn(date, dow);
+  }
+
+  public dayEarlier(): LinkedService {
+    return new LinkedService(this.from.dayEarlier(), this.to.dayEarlier());
   }
 }

--- a/src/network/Network.ts
+++ b/src/network/Network.ts
@@ -3,6 +3,7 @@ import { getDateNumber } from "../query/DateUtil.js";
 import type { GTFSFeed } from "../gtfs/GTFSLoader.js";
 import { createTripCalendar, getCalendarWindow } from "./TripCalendar.js";
 import { normalise } from "../gtfs/Normalise.js";
+import { coupledTripIds } from "../gtfs/LinkedTrips.js";
 import { DROP_OFF, PICK_UP, type RouteIdx, type StopIdx, type Timetable } from "./Timetable.js";
 
 const DEFAULT_INTERCHANGE_TIME = 0;
@@ -28,8 +29,12 @@ export function createNetwork(feed: GTFSFeed, date?: Date): Network {
   if (date) {
     const dateNumber = getDateNumber(date);
     const dow = date.getDay() as DayOfWeek;
+    const coupled = coupledTripIds(feed.links);
 
-    feed = { ...feed, trips: feed.trips.filter(trip => trip.service.runsOn(dateNumber, dow)) };
+    feed = {
+      ...feed,
+      trips: feed.trips.filter(trip => coupled.has(trip.tripId) || trip.service.runsOn(dateNumber, dow))
+    };
   }
 
   const { trips, calls, transfers, interchange, stations } = normalise(feed);

--- a/src/network/TripCalendar.ts
+++ b/src/network/TripCalendar.ts
@@ -1,6 +1,6 @@
 import type { DateNumber, Trip } from "../gtfs/GTFS.js";
 import type { Network } from "./Network.js";
-import type { Service } from "../gtfs/Service.js";
+import type { ServiceCalendar } from "../gtfs/Service.js";
 import { addDays, daysBetween, getDateNumber, getDayOfWeek } from "../query/DateUtil.js";
 
 /**
@@ -24,8 +24,8 @@ export function createTripCalendar(trips: Trip[], startDate: DateNumber, endDate
   const runs = new Uint8Array(days * stride);
 
   // there are far fewer services than trips, so each one is only evaluated once per day
-  const services: Service[] = [];
-  const serviceIndex = new Map<Service, number>();
+  const services: ServiceCalendar[] = [];
+  const serviceIndex = new Map<ServiceCalendar, number>();
   const tripService = new Int32Array(trips.length);
 
   for (let trip = 0; trip < trips.length; trip++) {

--- a/test/unit/gtfs/GTFSLoader.spec.ts
+++ b/test/unit/gtfs/GTFSLoader.spec.ts
@@ -66,6 +66,33 @@ describe("loadGTFS", () => {
     expect(false).toBe(feed.trips[0].service.runsOn(20240601, 1));
   });
 
+  it("reads a coupling as a link and leaves the interchange times alone", async () => {
+    const feed = await loadGTFS(feedZip({
+      ...FEED,
+      "trips.txt": "trip_id,service_id\nt1,s1\nt2,s1\n",
+      "transfers.txt":
+        "from_stop_id,to_stop_id,from_trip_id,to_trip_id,transfer_type,min_transfer_time\n"
+        + "A,A,,,2,300\n"
+        + "B,B,t1,t2,4,\n"
+    }));
+
+    expect([{ fromTripId: "t1", toTripId: "t2", fromStop: "B", toStop: "B" }]).toEqual(feed.links);
+    expect(300).toBe(feed.interchange.A);
+    expect(undefined).toBe(feed.interchange.B);
+  });
+
+  it("ignores transfers that are forbidden or need re-boarding", async () => {
+    const feed = await loadGTFS(feedZip({
+      ...FEED,
+      "transfers.txt":
+        "from_stop_id,to_stop_id,transfer_type,min_transfer_time\nA,A,3,\nA,B,3,600\nB,B,5,\n"
+    }));
+
+    expect(0).toBe(feed.links.length);
+    expect(0).toBe(Object.keys(feed.interchange).length);
+    expect(0).toBe(Object.keys(feed.transfers).length);
+  });
+
   it("reports progress and finishes with the building phase", async () => {
     const reports: LoadProgress[] = [];
 

--- a/test/unit/gtfs/LinkedTrips.spec.ts
+++ b/test/unit/gtfs/LinkedTrips.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import type { StopID, Trip, TripLink } from "../../../src/gtfs/GTFS.js";
+import { linkTrips } from "../../../src/gtfs/LinkedTrips.js";
+import { Service } from "../../../src/gtfs/Service.js";
+import { st } from "../util.js";
+
+// 20180101 is a Monday
+const MONDAY = 20180101;
+const TUESDAY = 20180102;
+const allDays = { 0: true, 1: true, 2: true, 3: true, 4: true, 5: true, 6: true };
+const noDays = { 0: false, 1: false, 2: false, 3: false, 4: false, 5: false, 6: false };
+const everyDay = new Service(20180101, 20181231, allDays, {});
+const mondays = new Service(20180101, 20181231, { ...noDays, 1: true }, {});
+const tuesdays = new Service(20180101, 20181231, { ...noDays, 2: true }, {});
+
+function trip(tripId: string, service: Service, ...stopTimes: Trip["stopTimes"]): Trip {
+  return { tripId, serviceId: tripId, stopTimes, service };
+}
+
+function link(fromTripId: string, toTripId: string, fromStop?: StopID, toStop?: StopID): TripLink {
+  return { fromTripId, toTripId, fromStop, toStop };
+}
+
+const platforms = new Map<StopID, StopID>([["B1", "B"], ["B2", "B"]]);
+const station = (stop: StopID): StopID => platforms.get(stop) ?? stop;
+
+const at = (t: Trip) => t.stopTimes.map(s => `${s.stop}@${s.arrivalTime}/${s.departureTime}`);
+
+describe("linkTrips", () => {
+
+  it("returns nothing when the feed has no links", () => {
+    expect(linkTrips([trip("a", everyDay, st("A", null, 100))], [], station)).toEqual([]);
+  });
+
+  it("joins a portion onto the trip it continues as", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, 200));
+    const base = trip("b", everyDay, st("B", 250, 300), st("C", 400, null));
+
+    const [linked] = linkTrips([portion, base], [link("p", "b", "B", "B")], station);
+
+    expect(linked.tripId).toBe("p_b");
+    expect(at(linked)).toEqual(["A@100/100", "B@200/300", "C@400/400"]);
+  });
+
+  it("splits a portion off part way along the trip it continues", () => {
+    const base = trip("b", everyDay, st("A", null, 100), st("B", 200, 250), st("C", 400, null));
+    const portion = trip("p", everyDay, st("B", 260, 300), st("D", 500, null));
+
+    const [linked] = linkTrips([base, portion], [link("b", "p", "B", "B")], station);
+
+    expect(at(linked)).toEqual(["A@100/100", "B@200/300", "D@500/500"]);
+  });
+
+  it("leaves both trips as they are", () => {
+    const base = trip("b", everyDay, st("A", null, 100), st("B", 200, 250), st("C", 400, null));
+    const portion = trip("p", everyDay, st("B", 260, 300), st("D", 500, null));
+
+    linkTrips([base, portion], [link("b", "p", "B", "B")], station);
+
+    expect(at(base)).toEqual(["A@100/100", "B@200/250", "C@400/400"]);
+    expect(at(portion)).toEqual(["B@260/300", "D@500/500"]);
+  });
+
+  it("takes set down from the arriving trip and pick up from the departing one", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, null));
+    const base = trip("b", everyDay, st("B", null, 300), st("C", 400, null));
+
+    const [linked] = linkTrips([portion, base], [link("p", "b", "B", "B")], station);
+
+    expect(linked.stopTimes[1].dropOff).toBe(true);
+    expect(linked.stopTimes[1].pickUp).toBe(true);
+  });
+
+  it("matches the coupling on the station rather than the platform", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B1", 200, 200));
+    const base = trip("b", everyDay, st("B2", 250, 300), st("C", 400, null));
+
+    const [linked] = linkTrips([portion, base], [link("p", "b", "B1", "B2")], station);
+
+    expect(at(linked)).toEqual(["A@100/100", "B1@200/300", "C@400/400"]);
+  });
+
+  it("couples end to end when the link names no stop", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, 200));
+    const base = trip("b", everyDay, st("B", 250, 300), st("C", 400, null));
+
+    const [linked] = linkTrips([portion, base], [link("p", "b")], station);
+
+    expect(at(linked)).toEqual(["A@100/100", "B@200/300", "C@400/400"]);
+  });
+
+  it("adds a day to a portion that leaves after midnight", () => {
+    const base = trip("b", mondays, st("A", null, 75600), st("B", 100800, 100800));
+    const portion = trip("p", tuesdays, st("B", 16080, 16080), st("C", 27000, null));
+
+    const [linked] = linkTrips([base, portion], [link("b", "p", "B", "B")], station);
+
+    expect(at(linked)).toEqual(["A@75600/75600", "B@100800/102480", "C@113400/113400"]);
+  });
+
+  it("runs on the arriving trip's day when the portion leaves after midnight", () => {
+    const base = trip("b", mondays, st("A", null, 75600), st("B", 100800, 100800));
+    const portion = trip("p", tuesdays, st("B", 16080, 16080), st("C", 27000, null));
+
+    const [linked] = linkTrips([base, portion], [link("b", "p", "B", "B")], station);
+
+    expect(linked.service.runsOn(MONDAY, 1)).toBe(true);
+    expect(linked.service.runsOn(TUESDAY, 2)).toBe(false);
+  });
+
+  it("runs only on the days both trips do", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, 200));
+    const base = trip("b", mondays, st("B", 250, 300), st("C", 400, null));
+
+    const [linked] = linkTrips([portion, base], [link("p", "b", "B", "B")], station);
+
+    expect(linked.service.runsOn(MONDAY, 1)).toBe(true);
+    expect(linked.service.runsOn(TUESDAY, 2)).toBe(false);
+  });
+
+  it("makes a trip for each portion of a train that splits more than once", () => {
+    const base = trip("b", everyDay, st("A", null, 100), st("B", 200, 250), st("C", 400, null));
+    const first = trip("p1", everyDay, st("B", 260, 300), st("D", 500, null));
+    const second = trip("p2", everyDay, st("B", 260, 320), st("E", 600, null));
+
+    const linked = linkTrips(
+      [base, first, second],
+      [link("b", "p1", "B", "B"), link("b", "p2", "B", "B")],
+      station
+    );
+
+    expect(linked.map(at)).toEqual([
+      ["A@100/100", "B@200/300", "D@500/500"],
+      ["A@100/100", "B@200/320", "E@600/600"]
+    ]);
+  });
+
+  it("ignores a link naming a trip the feed does not have", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, 200));
+
+    expect(linkTrips([portion], [link("p", "missing", "B", "B")], station)).toEqual([]);
+  });
+
+  it("ignores a link naming a stop neither trip calls at", () => {
+    const portion = trip("p", everyDay, st("A", null, 100), st("B", 200, 200));
+    const base = trip("b", everyDay, st("B", 250, 300), st("C", 400, null));
+
+    expect(linkTrips([portion, base], [link("p", "b", "Z", "Z")], station)).toEqual([]);
+  });
+
+  it("ignores a coupling that a day's shift cannot put in order", () => {
+    const base = trip("b", everyDay, st("A", null, 3600), st("B", 108000, 108000));
+    const portion = trip("p", everyDay, st("B", 7200, 7200), st("C", 20000, null));
+
+    expect(linkTrips([base, portion], [link("b", "p", "B", "B")], station)).toEqual([]);
+  });
+
+});

--- a/test/unit/gtfs/Service.spec.ts
+++ b/test/unit/gtfs/Service.spec.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { allDays } from "../util.js";
-import { Service } from "../../../src/gtfs/Service.js";
+import { LinkedService, Service } from "../../../src/gtfs/Service.js";
+
+// 20180101 is a Monday
+const MONDAY = 20180101;
+const TUESDAY = 20180102;
+const noDays = { 0: false, 1: false, 2: false, 3: false, 4: false, 5: false, 6: false };
+const onlyOn = (dow: number) => ({ ...noDays, [dow]: true });
 
 describe("Service", () => {
 
@@ -80,6 +86,45 @@ describe("Service", () => {
     const result = service.runsOn(20181022, 1);
 
     expect(result).toBe(false);
+  });
+
+});
+
+describe("Service.dayEarlier", () => {
+
+  it("moves the days of the week back one", () => {
+    const service = new Service(20180101, 20181231, onlyOn(2), {}).dayEarlier();
+
+    expect(service.runsOn(MONDAY, 1)).toBe(true);
+    expect(service.runsOn(TUESDAY, 2)).toBe(false);
+  });
+
+  it("moves the date range back one", () => {
+    const service = new Service(20180102, 20180102, allDays, {}).dayEarlier();
+
+    expect(service.runsOn(MONDAY, 1)).toBe(true);
+    expect(service.runsOn(TUESDAY, 2)).toBe(false);
+  });
+
+  it("moves exception dates back one", () => {
+    const service = new Service(20180101, 20181231, onlyOn(2), { 20180109: false }).dayEarlier();
+
+    expect(service.runsOn(MONDAY, 1)).toBe(true);
+    expect(service.runsOn(20180108, 1)).toBe(false);
+  });
+
+});
+
+describe("LinkedService", () => {
+
+  it("runs on the days both services do", () => {
+    const service = new LinkedService(
+      new Service(20180101, 20181231, allDays, {}),
+      new Service(20180101, 20180101, allDays, {})
+    );
+
+    expect(service.runsOn(MONDAY, 1)).toBe(true);
+    expect(service.runsOn(TUESDAY, 2)).toBe(false);
   });
 
 });

--- a/test/unit/network/Network.spec.ts
+++ b/test/unit/network/Network.spec.ts
@@ -349,4 +349,26 @@ describe("Network", () => {
     expect(trips[0].stopTimes.map(s => s.stop)).toEqual(["9100NRCH4", "9100DISS1"]);
   });
 
+  it("adds the trip a passenger stays on across a coupling", () => {
+    const portion = t(st("A", null, 1000), st("B", 1100, 1100));
+    const base = t(st("B", 1150, 1200), st("C", 1300, null));
+    const link = { fromTripId: portion.tripId, toTripId: base.tripId, fromStop: "B", toStop: "B" };
+
+    const { trips } = createNetwork(feed([portion, base], {}, {}, {}, [link]));
+
+    expect(trips.length).toBe(3);
+    expect(trips.some(trip => trip.tripId === `${portion.tripId}_${base.tripId}`)).toBe(true);
+  });
+
+  it("keeps a coupled trip when planning for a single date", () => {
+    const portion = t(st("A", null, 1000), st("B", 1100, 1100));
+    const base = t(st("B", 1150, 1200), st("C", 1300, null));
+    const link = { fromTripId: portion.tripId, toTripId: base.tripId, fromStop: "B", toStop: "B" };
+    const outsideTheCalendar = new Date("2017-06-01T12:00:00Z");
+
+    const { trips } = createNetwork(feed([portion, base], {}, {}, {}, [link]), outsideTheCalendar);
+
+    expect(trips.some(trip => trip.tripId === `${portion.tripId}_${base.tripId}`)).toBe(true);
+  });
+
 });

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -1,4 +1,4 @@
-import type { Interchange, StopID, StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip } from "../../src/gtfs/GTFS.js";
+import type { Interchange, StopID, StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip, TripLink } from "../../src/gtfs/GTFS.js";
 import type { GTFSFeed } from "../../src/gtfs/GTFSLoader.js";
 import type { Journey, TimetableLeg } from "../../src/results/Journey.js";
 import { Service } from "../../src/gtfs/Service.js";
@@ -24,10 +24,18 @@ export function feed(
   trips: Trip[],
   transfers: TransfersByOrigin = {},
   interchange: Interchange = {},
-  stops: StopIndex = {}
+  stops: StopIndex = {},
+  links: TripLink[] = []
 ): GTFSFeed {
   // wide enough for every date the specs plan for
-  return { trips, transfers, interchange, stops, feedInfo: { startDate: 20180101, endDate: 20201231 } };
+  return {
+    trips,
+    transfers,
+    links,
+    interchange,
+    stops,
+    feedInfo: { startDate: 20180101, endDate: 20201231 }
+  };
 }
 
 let tripId = 0;


### PR DESCRIPTION
A split or join reaches us as a `transfers.txt` row of `transfer_type=4` naming two trips. Nothing read it, so a through journey over one was planned as a change of trains — the interchange time charged at a station the passenger never got off at, and the connection dropped outright wherever the split dwell was shorter than the interchange.

Each link now adds the through trip alongside the two it couples: the arriving trip's calls up to the coupling, then the departing trip's. Neither of the two is touched, because each still runs alone on the days the other does not, and each is still boarded by passengers who really do change.

```
Sun 6 Sep  Euston -> Edinburgh    23:30 -> 31:52  legs=2  EUS-MTH-EDB     before
                                  23:30 -> 31:30  legs=1  EUS-EDB         after
Mon 7 Sep  Euston -> Fort Wm      20:25 -> 34:00  legs=3  EUS-KGX-EDB-FTW before
                                  21:15 -> 34:00  legs=1  EUS-FTW         after
```

### Where the day change goes

A trip tells its times in its own service day, so a portion leaving after midnight departs *earlier in the day* than the trip it continues arrived: the Lowland Sleeper's base reaches Carstairs at 30:15 on the 6th and the Edinburgh portion leaves at 06:40 on the 7th.

The portion is moved onto the arriving trip's day — 30:40 — and only ever forwards. Anchoring on the arriving trip means a portion running *before* the base never has to be told in a time before `00:00`, so the `N`/`P` distinction never arises. Which way round the feed meant it is read from the times, because `transfers.txt` carries no date indicator, and a coupling that a day's shift cannot put in order is left unmerged rather than shifted into nonsense.

### Calendars

The merged calendar is the two trips' calendars intersected, with the portion's rewritten a day earlier where it was shifted. That is exact — a transfer applies on the days both trips run, and `transfers.txt` has no calendar of its own to narrow it further.

`Service.dayEarlier()` does the rewrite once at build time: day-of-week rotated, date range and exception dates moved back one. `LinkedService.runsOn` is then a plain same-day `&&` with no date arithmetic in the per-day calendar loop, which is what keeps the cost off the build.

### Also

`transfer_type` 3 and 5 are now dropped rather than read as footpaths. Neither gives `min_transfer_time` a value, so before this a coupling wrote a zero over the interchange time at the station it happened at — the example feed's couplings name platforms and its interchange rows name stations, so the station row happened to be read last and win, but only by the order of the file.

Planning for a single date keeps the coupled trips whatever date is asked for. A portion leaving after midnight runs on the day *after* the trip it continues, so filtering first would drop it before it could be merged. The calendar still decides which of them can be boarded.

### Measured

Over the example feed's 2,833 couplings: all merge, none skipped, 159 needing the day shift.

| | before | after | |
|---|---|---|---|
| network build | 784ms | 813ms | **+3.7%** |
| heap | 305MB | 306MB | +1MB |
| trips | 292,211 | 295,044 | +2,833 (+1.0%) |
| routes | 19,036 | 19,251 | +215 |

Five runs each. Loading is unchanged. The cost is proportional to the extra trips with no fixed overhead: `linkTrips` returns immediately on a feed with no links, and indexes only the few thousand trips the links name rather than all 292k.

### Not in this

`TripScanner` reads one day's calendar slice with no scan of the day before, so a trip whose times run past 24:00 is invisible to a query on the day it actually operates. On this feed that is 19,281 trips with a stop time at or past 24:00, and 5,595 that depart entirely after midnight. Independent of this change, and the larger of the two.

### Verification

214 tests, `npm run lint`, `npm run typecheck`. New specs for `linkTrips`, `Service.dayEarlier`, `LinkedService`, the loader's reading of couplings, and the date-filtered network.

https://claude.ai/code/session_01VSVD9qL1EcyDvJm9P5rPEb
