### PR TITLE
Split every trip that overtakes a route, at any of its calls

### DIFF
--- a/src/network/Network.ts
+++ b/src/network/Network.ts
@@ -1,4 +1,4 @@
-import type { DayOfWeek, StopID, StopTime, Time, Transfer, Trip } from "../gtfs/GTFS.js";
+import type { DayOfWeek, StopID, StopTime, Transfer, Trip } from "../gtfs/GTFS.js";
 import { getDateNumber } from "../query/DateUtil.js";
 import type { GTFSFeed } from "../gtfs/GTFSLoader.js";
 import { createTripCalendar, getCalendarWindow } from "./TripCalendar.js";
@@ -13,7 +13,6 @@ const DEFAULT_INTERCHANGE_TIME = 0;
  * the Int32Array it is packed into. Any time past the largest one a feed can express will do.
  */
 const NO_END_TIME = 0x7fffffff;
-const OVERTAKING_ROUTE_SUFFIX = "|overtakes";
 
 /**
  * Build the timetable the algorithm scans, and the tables that turn its integers back into the
@@ -173,32 +172,34 @@ function groupTripsIntoRoutes(
     return index;
   };
 
-  const routeIndex = new Map<string, RouteIdx>();
+  const routeIndex = new Map<string, RouteIdx[]>();
   const routeStops: StopIdx[][] = [];
   const routeTrips: Trip[][] = [];
   const routeCalls: StopTime[][][] = [];
-  const routeLatestArrival: Time[] = [];
+  const routeLatestCalls: StopTime[][] = [];
 
   for (let i = 0; i < trips.length; i++) {
     const tripCalls = calls[i];
     const stops = tripCalls.map(stopTime => internStop(stopTime.stop));
 
-    let signature = routeSignature(stops, tripCalls);
-    const existing = routeIndex.get(signature);
+    const signature = routeSignature(stops, tripCalls);
+    const candidates = routeIndex.get(signature);
 
-    if (existing !== undefined && finalArrival(tripCalls) < routeLatestArrival[existing]) {
-      signature += OVERTAKING_ROUTE_SUFFIX;
-    }
-
-    let route = routeIndex.get(signature);
+    let route = candidates?.find(r => !overtakes(routeLatestCalls[r], tripCalls));
 
     if (route === undefined) {
       route = routeStops.length;
-      routeIndex.set(signature, route);
       routeStops.push(stops);
       routeTrips.push([]);
       routeCalls.push([]);
-      routeLatestArrival.push(Number.MIN_SAFE_INTEGER);
+      routeLatestCalls.push(tripCalls);
+
+      if (candidates === undefined) {
+        routeIndex.set(signature, [route]);
+      }
+      else {
+        candidates.push(route);
+      }
 
       // walk backwards so that on a route calling at a stop twice, the earlier call wins
       for (let p = stops.length - 1; p >= 0; p--) {
@@ -210,10 +211,7 @@ function groupTripsIntoRoutes(
 
     routeTrips[route].push(trips[i]);
     routeCalls[route].push(tripCalls);
-
-    if (finalArrival(tripCalls) > routeLatestArrival[route]) {
-      routeLatestArrival[route] = finalArrival(tripCalls);
-    }
+    routeLatestCalls[route] = tripCalls;
   }
 
   // transfers can reach stops that no trip calls at, so they are interned after the trips
@@ -236,13 +234,22 @@ function routeSignature(stops: StopIdx[], calls: StopTime[]): string {
 }
 
 /**
- * A trip overtakes a route when it arrives earlier than a trip that departed before it. Raptor
- * needs the trips on a route to be ordered, so an overtaking trip is put on a route of its own.
+ * A trip overtakes a route when it calls earlier than a trip already on it, at any of its calls.
+ * Raptor walks a route's trips backwards and stops at the first that departs too early, which is
+ * only sound if the trips are ordered at every call rather than just at the last one, so an
+ * overtaking trip is put on a route of its own.
  *
- * Trips are added in departure order, so comparing against the latest arrival so far is enough.
+ * Trips are added in departure order and none of them overtakes the route it is added to, so the
+ * trip added last is the latest at every call and comparing against it is enough.
  */
-function finalArrival(calls: StopTime[]): Time {
-  return calls[calls.length - 1].arrivalTime;
+function overtakes(latest: StopTime[], calls: StopTime[]): boolean {
+  for (let p = 0; p < calls.length; p++) {
+    if (calls[p].arrivalTime < latest[p].arrivalTime || calls[p].departureTime < latest[p].departureTime) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/test/unit/network/Network.spec.ts
+++ b/test/unit/network/Network.spec.ts
@@ -82,6 +82,41 @@ describe("Network", () => {
     expect(tripsOnRoute(timetable, 1)).toBe(1);
   });
 
+  it("separates a trip that overtakes at an intermediate call but not at the last", () => {
+    const { timetable } = createNetwork(feed([
+      t(st("A", null, 1000), st("B", 1500, 1600), st("C", 2000, null)),
+      // reaches B first, but is caught up with again by C
+      t(st("A", null, 1100), st("B", 1200, 1300), st("C", 2100, null))
+    ]));
+
+    expect(routeCount(timetable)).toBe(2);
+    expect(tripsOnRoute(timetable, 0)).toBe(1);
+    expect(tripsOnRoute(timetable, 1)).toBe(1);
+  });
+
+  it("separates every overtaking trip, not just the first", () => {
+    const { timetable } = createNetwork(feed([
+      t(st("A", null, 1000), st("B", 4000, null)),
+      t(st("A", null, 2000), st("B", 3500, null)),
+      t(st("A", null, 3000), st("B", 3200, null))
+    ]));
+
+    expect(routeCount(timetable)).toBe(3);
+    expect(tripsOnRoute(timetable, 0)).toBe(1);
+    expect(tripsOnRoute(timetable, 1)).toBe(1);
+    expect(tripsOnRoute(timetable, 2)).toBe(1);
+  });
+
+  it("keeps trips that call at the same times on one route", () => {
+    const { timetable } = createNetwork(feed([
+      t(st("A", null, 1000), st("B", 1100, null)),
+      t(st("A", null, 1000), st("B", 1100, null))
+    ]));
+
+    expect(routeCount(timetable)).toBe(1);
+    expect(tripsOnRoute(timetable, 0)).toBe(2);
+  });
+
   it("lays the stop times out trip-major within each route", () => {
     const { timetable } = createNetwork(feed([
       t(st("A", null, 1000), st("B", 1100, 1150), st("C", 1200, null)),


### PR DESCRIPTION
`TripScanner` walks a route's trips backwards and stops at the first one that departs too early (`TripScanner.ts:47`). That is only sound if the trips of a route are ordered at **every** call. They are not, and two independent gaps let unordered trips share a route.

### 1. Only the last call was compared

`finalArrival` compared the arrival at the last call only. A trip can depart later, overtake at an intermediate call, and be caught up with again by the end — the final arrivals are in order, the intermediate ones are not.

### 2. Only the base route was ever tested

```ts
const existing = routeIndex.get(signature);            // the base route

if (existing !== undefined && finalArrival(tripCalls) < routeLatestArrival[existing]) {
  signature += OVERTAKING_ROUTE_SUFFIX;
}

let route = routeIndex.get(signature);
```

The overtaking test was only made against the base route. Once a trip was diverted onto `signature|overtakes` it was added there with no comparison against the trips already on it, so that route accumulated trips in arbitrary order. And with a single suffix, a third distinct order had nowhere to go.

### The effect

On a national GTFS feed, **3516 of 19251 routes (18.3%)** had trips that were not sorted by departure time at every position, across 16728 positions, largest inversion 55 minutes. Because the trip search stops at the first trip departing too early, where the search *starts* then changes what it finds — so the scan silently misses reachable trips. Comparing against a search that starts at each route's last trip, arrival times differed at **2108 stops in the earlier-arrival direction**, one of them from unreachable to reachable.

An example the old check let through, trips 0-3 all departing 02:08 and diverging by the fourth call:

```
  trip  0  02:08 02:13 02:17 02:32 02:39 02:54 03:01
  trip  1  02:08 02:13 02:16 02:31 02:37 02:51 02:58
  trip  2  02:08 02:13 02:16 02:30 02:36 02:50 02:58
```

### The fix

Trips with the same signature now keep a list of routes, and a trip joins the first route it does not overtake at any of its calls, creating a new one if there is none. A signature can therefore carry as many routes as the timetable needs.

Trips are added in departure order and none overtakes the route it joins, so the trip added last is the latest at every call — comparing against that one alone is enough, and no per-route maximum has to be maintained.

### Cost

| | before | after |
|---|---|---|
| routes with unordered trips | 3516 | **0** |
| routes | 19251 | 23655 (+22.9%) |
| `test/performance.ts` planning | 1.080s | 1.240s |

The extra routes make the queue longer, so planning is ~15% slower. #50 is independent of this branch and more than covers it.

Three tests added. The two that assert the separation both fail on `master`; the third guards against splitting trips that call at identical times.

https://claude.ai/code/session_01VSVD9qL1EcyDvJm9P5rPEb