### PR TITLE
Reset the trip scan position for each route traversal

### DIFF
--- a/src/raptor/RaptorAlgorithm.ts
+++ b/src/raptor/RaptorAlgorithm.ts
@@ -53,6 +53,7 @@ export class RaptorAlgorithm {
       const route = this.queue.routeAt(q);
 
       this.routes.moveTo(route);
+      tripScanner.startRoute(this.routes);
 
       let boardingPoint = -1;
       let trip = NO_TRIP;

--- a/src/raptor/RouteCursor.ts
+++ b/src/raptor/RouteCursor.ts
@@ -15,6 +15,7 @@ export class RouteCursor {
   private timesBase = 0;
   private firstTrip = 0;
   private stopsInRoute = 0;
+  private tripsInRoute = 0;
 
   constructor(private readonly routes: Routes) { }
 
@@ -33,6 +34,13 @@ export class RouteCursor {
   }
 
   /**
+   * Number of trips on the route
+   */
+  public get numTrips(): number {
+    return this.tripsInRoute;
+  }
+
+  /**
    * Position the cursor on a route, resolving where its slice of each global array starts.
    */
   public moveTo(route: RouteIdx): void {
@@ -43,6 +51,7 @@ export class RouteCursor {
     this.stopsInRoute = stopOffsets[route + 1] - this.stopsBase;
     this.timesBase = stopTimesBase[route];
     this.firstTrip = tripOffsets[route];
+    this.tripsInRoute = tripOffsets[route + 1] - this.firstTrip;
   }
 
   public stopAt(position: number): StopIdx {

--- a/src/raptor/TripScanner.ts
+++ b/src/raptor/TripScanner.ts
@@ -13,8 +13,8 @@ export const NO_TRIP = -1;
  * returned in order to reduce plan time.
  */
 export class TripScanner {
-  /** Trip each route is scanned back from, starting at its last trip and only ever moving earlier */
-  private readonly scanPosition: Int32Array;
+  /** Trip the route being traversed is scanned back from, which only ever moves earlier */
+  private scanPosition = 0;
   /** The calendar's slice for the date being scanned, or an empty one outside the period it covers */
   private readonly runsToday: Uint8Array;
 
@@ -22,13 +22,21 @@ export class TripScanner {
     const calendar = routes.calendar;
     const offset = dayOffset(calendar, date);
 
-    this.scanPosition = Int32Array.from(
-      { length: routes.tripOffsets.length - 1 },
-      (_, route) => routes.tripOffsets[route + 1] - routes.tripOffsets[route] - 1
-    );
     this.runsToday = offset === NOT_COVERED
       ? new Uint8Array(calendar.stride)
       : calendar.runs.subarray(offset, offset + calendar.stride);
+  }
+
+  /**
+   * Start traversing the route the cursor is positioned on, scanning back from its last trip.
+   *
+   * The scan position is only valid for one traversal. The trip to board can only get earlier as
+   * a route is walked, because a trip is only looked for at all where the stop can be reached
+   * before the trip already boarded departs it, but a later traversal of the same route may start
+   * at an earlier stop or a later time and need a trip further on than the last one found.
+   */
+  public startRoute(cursor: RouteCursor): void {
+    this.scanPosition = cursor.numTrips - 1;
   }
 
   /**
@@ -36,13 +44,12 @@ export class TripScanner {
    * boarded at the given position, or NO_TRIP if there isn't one.
    */
   public earliestTrip(cursor: RouteCursor, position: number, time: Time): number {
-    const route = cursor.route;
     const runsToday = this.runsToday;
 
     let lastFound = NO_TRIP;
 
     // iterate backwards through the trips on the route, starting where we last found a trip
-    for (let i = this.scanPosition[route]; i >= 0; i--) {
+    for (let i = this.scanPosition; i >= 0; i--) {
       // if the trip is unreachable, exit the loop
       if (cursor.departure(i, position) < time) {
         break;
@@ -59,7 +66,7 @@ export class TripScanner {
       // as there may be some services that are reachable but not running before the last found service and searching
       // must continue from the last reachable point.
       if (lastFound === NO_TRIP || lastFound === i) {
-        this.scanPosition[route] = i;
+        this.scanPosition = i;
       }
     }
 

--- a/test/unit/raptor/TripScanner.spec.ts
+++ b/test/unit/raptor/TripScanner.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { createNetwork } from "../../../src/network/Network.js";
+import { RaptorAlgorithm } from "../../../src/raptor/RaptorAlgorithm.js";
+import { getDateNumber } from "../../../src/query/DateUtil.js";
+import { feed, st, t } from "../util.js";
+
+describe("TripScanner", () => {
+
+  it("finds a trip when a route is traversed again from an earlier stop", () => {
+    const trips = [
+      t(st("A", null, 900), st("M", 915, 915), st("B", 930, 930), st("C", 1000, null)),
+      t(st("A", null, 1000), st("M", 1015, 1015), st("B", 1030, 1030), st("C", 1100, null)),
+      t(st("A", null, 1100), st("M", 1115, 1115), st("B", 1130, 1130), st("C", 1200, null)),
+      // reaches B, so the route above is first traversed from B, boarding its second trip
+      t(st("O", null, 1000), st("B", 1015, null)),
+      // reaches A from B, so the route is traversed again from A a round later, where only its
+      // third trip can be caught. A scan position carried over from the traversal at B starts
+      // below that trip and finds nothing
+      t(st("B", null, 1020), st("A", 1040, null))
+    ];
+
+    const network = createNetwork(feed(trips));
+    const raptor = new RaptorAlgorithm(network.timetable);
+    const origin = network.stopIndex.get("O") as number;
+    const [, arrivals] = raptor.scan(new Map([[origin, 900]]), getDateNumber(new Date("2018-10-16")));
+
+    expect(arrivals[network.stopIndex.get("M") as number]).toBe(1115);
+  });
+
+});


### PR DESCRIPTION
`TripScanner` walks a route's trips backwards from where it last found one, so repeated searches on a route do not rescan trips already ruled out. That is sound, but only within a single traversal of a route. The paper scopes it exactly that way:

> For each stop, we must find the earliest trip et(r, ·). If we keep the list of trips serving r sorted by time, **while traversing r** we can find all et(r, ·) values with a single sweep over this list, since et(r, ·) can only decrease.
>
> — Delling, Pajor & Werneck, *Round-Based Public Transit Routing*

It can only decrease because of the guard in their pseudocode:

```
22   t ← ⊥                                          . the current trip
...
29   if τk−1(pi) + τch(pi) < τdep(t, pi) then        . can we catch an earlier trip at pi?
30       t ← et(r, pi)
```

A trip is only looked for where the stop can be reached before the trip already boarded departs it, so the answer is never above the trip in hand — and `t` is reset for every traversal.

### The bug

`scanPosition` was an `Int32Array` indexed by route, allocated once per query, so it carried from one traversal of a route to the next. A later traversal can enter the route at an **earlier stop**, and a trip departs an earlier stop sooner, so meeting the same time there needs a trip **further on** than the last one found. The sweep starts below it, reads a departure that is too early, breaks, and reports no trip at all.

Only the stops **between the new entry point and the old one** are lost. Trips are ordered, so a trip above the scan position arrives later at every stop from the old entry point onwards and could not have improved those anyway — but the stops before it got nothing from the earlier traversal, and nothing else reaches them.

The added test is the smallest case: a route traversed from `B` in one round and from `A` in the next, with a stop between them. On `master` that stop comes back `NOT_REACHED`.

### The fix

The scan position becomes a scalar reset at the start of each traversal — the paper's algorithm. `RouteCursor` gains `numTrips` to size the reset.

### Correctness

Against a reference that relaxes every route every round until nothing improves (one trip per round, converging in 6-7 rounds against the scan's 7.5, so round count is not the limit):

| | later than the earliest arrival | earlier |
|---|---|---|
| before | 357 of 11336 stop results | 0 |
| after | **0 of 68016** stop results | 0 |

### Performance

Unchanged within measurement noise. Finding more trips marks more stops, so a scan does slightly *more* work — 7.5 rounds instead of 7.4, and 2.6% more stop positions — but end to end the two are indistinguishable on this hardware:

| | median ms per scan, five runs | `test/performance.ts` planning |
|---|---|---|
| before | 8.92 | 634-763ms |
| after | 8.26 | 580-739ms |

Both return the same 504 journeys from `test/performance.ts`.

https://claude.ai/code/session_01VSVD9qL1EcyDvJm9P5rPEb