### PR TITLE
Name a transfer pattern once rather than once per path

### DIFF
--- a/src/transfer-pattern/results/StringResults.ts
+++ b/src/transfer-pattern/results/StringResults.ts
@@ -1,16 +1,22 @@
-import { isTransfer, type Connection, type ConnectionIndex } from "../../raptor/Connection.js";
+import { isTransfer, originIndexOf, type Connection, type ConnectionIndex } from "../../raptor/Connection.js";
 import type { Network } from "../../network/Network.js";
-import { originIndexOf } from "../../raptor/Connection.js";
 import type { StopIdx } from "../../network/Timetable.js";
-import type { Time } from "@gb-transit/gtfs-loader";
-import type { Path } from "./TransferPatternResults.js";
+import type { StopID, Time } from "@gb-transit/gtfs-loader";
 
 /**
  * Store the kConnection results as an index where the key is the journey origin and destination and the value is a Set
  * of change points.
+ *
+ * A day of scans from one station finds the same patterns over and over: on a national feed some
+ * two million paths turn into a few thousand of them. Naming a path costs more than discovering it
+ * has been seen before, so the change points are collected into a tree and only turned into
+ * strings by finalize, once each.
  */
 export class StringResults {
-  private results: TransferPatternIndex = {};
+  /** Origin stop, then destination stop, then the change points between them */
+  private readonly journeys = new Map<StopID, Map<StopID, PatternNode>>();
+  /** Reused by every path, since a path is filed as soon as it has been walked */
+  private readonly changePoints: StopID[] = [];
 
   /**
    * Extract the path from each kConnection result and store it in an index
@@ -19,19 +25,15 @@ export class StringResults {
     let nextDepartureTime = Number.MAX_SAFE_INTEGER;
 
     for (let stop = 0; stop < kConnections.length; stop++) {
-      const destination = network.stopIds[stop];
+      const rounds = kConnections[stop];
 
-      for (const k in kConnections[stop]) {
-        const [path, departureTime] = this.getPath(kConnections, k, stop, network);
+      for (let k = 1; k < rounds.length; k++) {
+        if (rounds[k] !== undefined) {
+          const departureTime = this.record(kConnections, k, stop, network);
 
-        if (path.length >= 1) {
-          const [origin, ...tail] = path;
-          const journeyKey = origin > destination ? destination + origin : origin + destination;
-          const pathString = origin > destination ? tail.reverse().join(",") : tail.join(",");
-
-          this.results[journeyKey] = this.results[journeyKey] || new Set();
-          this.results[journeyKey].add(pathString);
-          nextDepartureTime = Math.min(nextDepartureTime, departureTime + 1);
+          if (departureTime !== undefined) {
+            nextDepartureTime = Math.min(nextDepartureTime, departureTime + 1);
+          }
         }
       }
     }
@@ -43,20 +45,46 @@ export class StringResults {
    * Return the results
    */
   public finalize(): TransferPatternIndex {
-    return this.results;
+    const results: TransferPatternIndex = {};
+
+    for (const [origin, destinations] of this.journeys) {
+      for (const [destination, pattern] of destinations) {
+        const key = origin + destination;
+
+        results[key] = results[key] ?? new Set();
+        name(pattern, [], results[key]);
+      }
+    }
+
+    return results;
   }
 
-  private getPath(
+  /**
+   * Walk back through the connections to the stop the journey started at, file the stops it was
+   * boarded at on the way, and return the time it left the first of them.
+   *
+   * Undefined where the connections lead nowhere, which is the only case the day's next departure
+   * should not be taken from.
+   */
+  private record(
     kConnections: ConnectionIndex,
-    k: string,
+    k: number,
     finalDestination: StopIdx,
     network: Network
-  ): [Path, Time] {
-    const path: Path = [];
-    let departureTime = Number.MAX_SAFE_INTEGER;
+  ): Time | undefined {
+    const changePoints = this.changePoints;
 
-    for (let destination = finalDestination, i = parseInt(k, 10); i > 0; i--) {
+    let departureTime = Number.MAX_SAFE_INTEGER;
+    let destination = finalDestination;
+    let length = 0;
+
+    for (let i = k; i > 0; i--) {
       const connection = kConnections[destination][i];
+
+      if (connection === undefined) {
+        break;
+      }
+
       const transfer = isTransfer(connection) ? network.transfers[connection] : undefined;
       const origin = transfer
         ? (network.stopIndex.get(transfer.origin) as StopIdx)
@@ -66,32 +94,121 @@ export class StringResults {
       // to a station and defaulted. The feed's own interchange is keyed by its stop ids, so it
       // cannot be looked up by the station a transfer names
       departureTime = transfer
-          ? departureTime - transfer.duration - network.timetable.interchange[destination]
-          : this.departureOf(network, connection as Connection);
+        ? departureTime - transfer.duration - network.timetable.interchange[destination]
+        : departureOf(network, connection as Connection);
 
-      path.unshift(network.stopIds[origin]);
-
+      changePoints[length++] = network.stopIds[origin];
       destination = origin;
     }
 
-    return [path, departureTime];
+    if (length === 0) {
+      return undefined;
+    }
+
+    this.file(changePoints, length, network.stopIds[finalDestination]);
+
+    return departureTime;
   }
 
   /**
-   * When the connection departs the stop it was boarded at.
+   * File a path under the pair of stops it runs between.
    *
-   * Read from the timetable rather than the feed's stop times, which hold the same departure but
-   * only after the calls have been counted past the passing points. It is the same value either
-   * way, and taking it from the timetable is what lets a pattern be built without the feed, so a
-   * worker can share a timetable rather than load a feed of its own.
+   * changePoints holds the stops it was boarded at, last first, so the stop it departed from is at
+   * the end. The pair is ordered by stop id, as the key is, and the tree is descended in the order
+   * that key will name the change points in, so nothing has to be reversed later.
    */
-  private departureOf(network: Network, [route, trip, from]: Connection): Time {
-    const { stopOffsets, stopTimesBase, tripOffsets, departures } = network.timetable.routes;
-    const stopsInRoute = stopOffsets[route + 1] - stopOffsets[route];
+  private file(changePoints: StopID[], length: number, arrival: StopID): void {
+    const departure = changePoints[length - 1];
+    const forwards = departure <= arrival;
 
-    return departures[stopTimesBase[route] + (trip - tripOffsets[route]) * stopsInRoute + from];
+    let node = this.patternsBetween(forwards ? departure : arrival, forwards ? arrival : departure);
+
+    if (forwards) {
+      for (let i = length - 2; i >= 0; i--) {
+        node = descend(node, changePoints[i]);
+      }
+    }
+    else {
+      for (let i = 0; i <= length - 2; i++) {
+        node = descend(node, changePoints[i]);
+      }
+    }
+
+    node.end = true;
   }
 
+  private patternsBetween(from: StopID, to: StopID): PatternNode {
+    let destinations = this.journeys.get(from);
+
+    if (destinations === undefined) {
+      destinations = new Map();
+      this.journeys.set(from, destinations);
+    }
+
+    let pattern = destinations.get(to);
+
+    if (pattern === undefined) {
+      pattern = newNode();
+      destinations.set(to, pattern);
+    }
+
+    return pattern;
+  }
+
+}
+
+/**
+ * When the connection departs the stop it was boarded at.
+ *
+ * Read from the timetable rather than the feed's stop times, which hold the same departure but
+ * only after the calls have been counted past the passing points. Taking it from the timetable is
+ * what lets a pattern be built without the feed, so a worker can share a timetable rather than
+ * load one of its own.
+ */
+function departureOf(network: Network, [route, trip, from]: Connection): Time {
+  const { stopOffsets, stopTimesBase, tripOffsets, departures } = network.timetable.routes;
+  const stopsInRoute = stopOffsets[route + 1] - stopOffsets[route];
+
+  return departures[stopTimesBase[route] + (trip - tripOffsets[route]) * stopsInRoute + from];
+}
+
+/**
+ * Name every pattern at or below this node, adding each to the set
+ */
+function name(node: PatternNode, changePoints: StopID[], into: Set<JourneyPattern>): void {
+  if (node.end) {
+    into.add(changePoints.join(","));
+  }
+
+  for (const [stop, child] of node.children) {
+    changePoints.push(stop);
+    name(child, changePoints, into);
+    changePoints.pop();
+  }
+}
+
+function descend(node: PatternNode, stop: StopID): PatternNode {
+  let child = node.children.get(stop);
+
+  if (child === undefined) {
+    child = newNode();
+    node.children.set(stop, child);
+  }
+
+  return child;
+}
+
+function newNode(): PatternNode {
+  return { children: new Map(), end: false };
+}
+
+/**
+ * A change point of a pattern and the change points that may follow it. `end` marks a pattern that
+ * stops here, which a longer one may also run through.
+ */
+interface PatternNode {
+  children: Map<StopID, PatternNode>;
+  end: boolean;
 }
 
 /**

--- a/test/unit/transfer-pattern/results/StringResults.spec.ts
+++ b/test/unit/transfer-pattern/results/StringResults.spec.ts
@@ -38,6 +38,16 @@ describe("StringResults", () => {
     expect(tree.finalize()).toEqual(expected);
   });
 
+  it("keeps a pattern that another pattern runs through", () => {
+    const tree = new StringResults();
+
+    mergePath(["A", "B", "D"], tree);
+    mergePath(["A", "B", "C", "D"], tree);
+
+    // changing at B and changing at B then C are both ways of getting from A to D
+    expect(tree.finalize().AD).toEqual(new Set(["B", "B,C"]));
+  });
+
   it("Adds different paths", () => {
     const tree = new StringResults();
     const expected = {


### PR DESCRIPTION
A day of scans from one station finds the same patterns over and over. On a national feed, Birmingham walks **2,015,027 paths to arrive at 2,783 journey keys** — all but about one in seven hundred is a pattern already known.

The cost was paid before anything could notice it was a duplicate. Every one of those paths allocated an array for its tail (`const [origin, ...tail] = path`), reversed it, joined it into a string, concatenated a key, and looked that up twice in a plain object — and only then met the `Set` that would throw it away.

A CPU profile of a day for four origins, with the one-off feed load excluded:

| | self time | share of generation |
|---|---|---|
| `RaptorAlgorithm.scanRoutes` | 1.907s | 45% |
| `StringResults.add` | 1.119s | 26% |
| `StringResults.getPath` | 0.615s | 14% |
| `Queue.build` | 0.416s | 10% |

`add` above `getPath`: naming a path cost more than finding it.

### The change

Change points go into a tree keyed by the stops themselves. A path that has been seen before ends at a node that already exists and costs nothing more; `finalize` walks the tree and names each pattern once. Rounds are also visited by index rather than with `for..in` over a sparse array, which drops the `parseInt` that went with it.

### Measured

Whole days, including the scanning, so the build side improves by considerably more than these figures:

| origin | before | after | |
|---|---|---|---|
| NRW | 0.62s | 0.37s | 1.68x |
| BHM | 2.06s | 1.33s | 1.54x |
| ORP | 0.93s | 0.69s | 1.34x |
| EDB | 1.06s | 0.62s | 1.70x |
| PNZ | 0.09s | 0.07s | 1.40x |
| WAT | 3.62s | 2.27s | 1.59x |
| MAN | 2.23s | 1.59s | 1.40x |
| LDS | 1.52s | 1.12s | 1.36x |
| **total** | **12.14s** | **8.07s** | **1.50x** |

Checked against `master`'s implementation on every one of those origins: the same patterns under the same keys, and the same departure time returned by every single round — so the day's loop follows the same course, not just the same destination.

### One test added, and it is not a regression test

`keeps a pattern that another pattern runs through` passes on `master` too. The old code kept whole strings in a `Set`, so a pattern that is a prefix of a longer one could not be lost. A tree has to mark it deliberately, and that is the classic way to get a tree like this wrong, so the invariant is now pinned.

### Note

An earlier cut of this kept the tree keyed by stop *index* and resolved names in `finalize`. That coupled the tree to a network's index space, and the existing spec calls `add` with a different network each time, which turned up as `"Aundefined"` keys. Keying by stop id removes the coupling and measures the same, so that is what this does.

Rebased onto master after #49. The only conflict was the import block: `StopID` and `Time` now come from `@gb-transit/gtfs-loader`, and `Path` is no longer imported since `getPath` is gone. Figures above are from re-running the comparison after the rebase rather than carrying the old ones over.