### PR TITLE
Carry route and operator information across the worker boundary

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,13 @@
+---
+"raptor-journey-planner": minor
+---
+
+Carry route and operator information across the worker boundary.
+
+A trip now crosses as everything the loader holds less its `Service`, so a leg arrives with the
+route it runs on, its `shortName` and its `headsign` — a headcode and a destination, for a UK rail
+feed. `PlannerClient.load` returns the feed's `routes` and `agencies` alongside the counts, sent
+once rather than denormalised onto every leg, so a leg's `routeId` resolves to a route and on to
+the operator that runs it.
+
+Requires `@gb-transit/gtfs-loader` 1.2.0, which reads `routes.txt` and `agency.txt`.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,24 @@ its `service`: a class does not survive being posted, so it would arrive with it
 without its `runsOn`, which is worse than leaving it out. Whether a trip runs on a date is settled
 inside the worker before the journey is returned.
 
+`load` hands back the feed's routes and agencies along with what it loaded. A leg names the route
+its trip runs on and stops there, so these are what turn that id into a route and an operator. They
+are sent once, when the feed loads, because a feed has few of them — the GB feed has 98 routes and
+41 agencies against 290,640 trips — and copying an operator's name onto every leg of every journey
+would cost more:
+
+```js
+const feed = await planner.load({ url: "/gtfs.zip" });
+const [journey] = await planner.plan(["PAD"], ["PLY"], new Date(), 9 * 60 * 60);
+const { trip } = journey.legs[0];
+const route = feed.routes[trip.routeId];
+
+`${trip.shortName} to ${trip.headsign}, ${feed.agencies[route.agencyId].name}`;
+// "GW130700 to Plymouth, GWR"
+```
+
+A feed need not name either, so `routeId` may be missing and the indexes empty.
+
 Passing `{ date }` to `load` restricts the timetable to that date, which makes it smaller and
 queries faster.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@gb-transit/gtfs-loader": "^1.1.0"
+        "@gb-transit/gtfs-loader": "^1.2.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.12",
@@ -917,25 +917,28 @@
       }
     },
     "node_modules/@gb-transit/gtfs-loader": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@gb-transit/gtfs-loader/-/gtfs-loader-1.1.0.tgz",
-      "integrity": "sha512-MR1xhPocbmP7f4Di4NIwXvbXXwrga9o/ezXP9DJL0bNavGmHMqH5rguRmwVmVNO5trCYu36NV3XPuHqXrTjbDA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@gb-transit/gtfs-loader/-/gtfs-loader-1.2.0.tgz",
+      "integrity": "sha512-HUzrPSkUtIzFB4N+zXcsQPNcrkI7xfDQQ3hPFrkUdXcG0sLkYWfzTZ8qO16BubZ71C6P6tbmjS2U1+U7p9zJaw==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@gb-transit/gtfs-schema": "^2.0.0",
+        "@gb-transit/gtfs-schema": "^2.1.0",
         "fflate": "^0.8.3"
       },
       "engines": {
-        "node": ">=26"
+        "node": ">=22"
       }
     },
     "node_modules/@gb-transit/gtfs-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@gb-transit/gtfs-schema/-/gtfs-schema-2.0.0.tgz",
-      "integrity": "sha512-YUgvbr0HsEZD+tTW5YJK6P4N3uv6eDuNmsJCN5/vEuioMJAhoLDj8Jw4ifsffuDjl0poA2Az7K5v90nynYqmog==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@gb-transit/gtfs-schema/-/gtfs-schema-2.1.0.tgz",
+      "integrity": "sha512-0LzLDawTr63YkyG3Pr5fVxpT0X2vuxm8O08GXIA+jJFg1ge/lS6Sw51xxpNwvUvn/+5GZl2qRtyQR5EtkMt24w==",
       "license": "GPL-3.0",
+      "dependencies": {
+        "temporal-polyfill": "1.0.4"
+      },
       "engines": {
-        "node": ">=26"
+        "node": ">=22"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2466,6 +2469,28 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.4.tgz",
+      "integrity": "sha512-MLEU0qOD2uXlz24oINNtdLZQl8RgmMxSnRtKEGZGGetTJjlRwQJjk+VsJ4EREaUoiaTb8NJOcUiKtoAiWn9EBg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "1.0.1",
+        "temporal-utils": "1.0.2"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.2.tgz",
+      "integrity": "sha512-1B8Dl4KzrOvsNUlpoWGno2VLQlxroLjDgc5NBjVC9ax9ymdo+ezfyvhyjEMx+IVfhINr6CIG2gcnlP95iRrybQ==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vitest": "^5.0.0"
   },
   "dependencies": {
-    "@gb-transit/gtfs-loader": "^1.1.0"
+    "@gb-transit/gtfs-loader": "^1.2.0"
   },
   "module": "./dist/esm/index.js",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,9 @@ export type { LoadOptions, LoadProgress } from "@gb-transit/gtfs-loader";
 export { TimeParser } from "@gb-transit/gtfs-loader";
 export { addDays, daysBetween, getDateNumber, getDayOfWeek } from "@gb-transit/gtfs-loader";
 export type {
-  Calendar, CalendarIndex, DateIndex, DateNumber, DayOfWeek, Duration, Interchange, ServiceID,
-  Stop, StopID, StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
+  Agency, AgencyID, AgencyIndex, Calendar, CalendarIndex, DateIndex, DateNumber, DayOfWeek,
+  Duration, Interchange, Route, RouteID, RouteIndex, ServiceID, Stop, StopID, StopIndex, StopTime,
+  Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
 } from "@gb-transit/gtfs-loader";
 export * from "./query/DepartAfterQuery.js";
 export * from "./query/RangeQuery.js";

--- a/src/worker/PlannerClient.ts
+++ b/src/worker/PlannerClient.ts
@@ -1,4 +1,4 @@
-import type { GTFSSource, LoadProgress, Stop, StopID, Time } from "@gb-transit/gtfs-loader";
+import type { AgencyIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time } from "@gb-transit/gtfs-loader";
 import {
   type FeedLocation,
   isEvent,
@@ -56,7 +56,12 @@ export class PlannerClient {
         throw new Error(`Unexpected reply to load: ${response.type}`);
       }
 
-      return { stops: response.stops, trips: response.trips };
+      return {
+        stops: response.stops,
+        trips: response.trips,
+        routes: response.routes,
+        agencies: response.agencies
+      };
     }
     finally {
       this.onProgress = undefined;
@@ -133,8 +138,26 @@ export class PlannerClient {
 
 }
 
+/**
+ * What the worker has, after loading a feed.
+ *
+ * The routes and agencies come with it because a journey's legs do not carry them: a leg names the
+ * route its trip runs on, and these are what turn that id into a route and an operator. They are
+ * few enough - the GB feed has under a hundred routes and 41 agencies - to send whole, once, which
+ * is cheaper than copying an operator's name onto every leg of every journey planned afterwards.
+ *
+ * ```js
+ * const feed = await planner.load({ url });
+ * const route = feed.routes[leg.trip.routeId];
+ * const operator = feed.agencies[route.agencyId].name;
+ * ```
+ */
 export interface LoadedFeed {
   /** Stations the timetable plans between */
   stops: number;
   trips: number;
+  /** Routes of the feed by route id, which is what a leg's trip names */
+  routes: RouteIndex;
+  /** Agencies of the feed by agency id, which is what a route names */
+  agencies: AgencyIndex;
 }

--- a/src/worker/PlannerHost.ts
+++ b/src/worker/PlannerHost.ts
@@ -50,7 +50,16 @@ export class PlannerHost {
 
     this.network = createNetwork(this.feed, request.date === undefined ? undefined : new Date(request.date));
 
-    return { id: request.id, type: "loaded", stops: this.network.stopIds.length, trips: this.network.trips.length };
+    // the routes and agencies go back once, here, rather than a route name and an operator name
+    // being copied onto every leg of every journey planned afterwards
+    return {
+      id: request.id,
+      type: "loaded",
+      stops: this.network.stopIds.length,
+      trips: this.network.trips.length,
+      routes: this.feed.routes,
+      agencies: this.feed.agencies
+    };
   }
 
   private plan(request: Extract<PlannerRequest, { type: "plan" }>): PlannerResponse {
@@ -99,14 +108,14 @@ function toPlainLeg(leg: PlainLeg | TimetableLeg): PlainLeg {
     return leg as PlainLeg;
   }
 
+  // everything a trip carries crosses except its Service, so the Service is taken off and the rest
+  // is kept as it is - a field the loader adds to Trip needs no change here to arrive with a leg
+  const { service, ...trip } = timetableLeg.trip;
+
   return {
     origin: timetableLeg.origin,
     destination: timetableLeg.destination,
     stopTimes: timetableLeg.stopTimes,
-    trip: {
-      tripId: timetableLeg.trip.tripId,
-      serviceId: timetableLeg.trip.serviceId,
-      stopTimes: timetableLeg.trip.stopTimes
-    }
+    trip
   };
 }

--- a/src/worker/Protocol.ts
+++ b/src/worker/Protocol.ts
@@ -1,19 +1,21 @@
 import type { TimetableLeg } from "../results/Journey.js";
-import type { GTFSSource, LoadProgress, ServiceID, Stop, StopID, StopTime, Time, Transfer, TripID } from "@gb-transit/gtfs-loader";
+import type {
+  AgencyIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time, Transfer, Trip
+} from "@gb-transit/gtfs-loader";
 
 /**
- * A trip as it crosses the worker boundary.
+ * A trip as it crosses the worker boundary: the trip, less its Service.
  *
- * The trip's Service does not come with it. Posting a message copies the data of an object but not
- * the class it belongs to, so a Service would arrive with its fields and without its runsOn, which
- * is worse than not sending it: the caller cannot see that it is broken. Whether a trip runs on a
- * date is settled inside the worker before the journey is returned anyway.
+ * Posting a message copies the data of an object but not the class it belongs to, so a Service
+ * would arrive with its fields and without its runsOn, which is worse than not sending it: the
+ * caller cannot see that it is broken. Whether a trip runs on a date is settled inside the worker
+ * before the journey is returned anyway.
+ *
+ * Everything else a trip carries is data and crosses as it is, so this says what is taken away
+ * rather than listing what is kept: a field the loader adds to Trip arrives on the other side
+ * without this file being touched, and reads there under the name it has here.
  */
-export interface PlainTrip {
-  tripId: TripID;
-  serviceId: ServiceID;
-  stopTimes: StopTime[];
-}
+export type PlainTrip = Omit<Trip, "service">;
 
 export type PlainLeg = Transfer | (Omit<TimetableLeg, "trip"> & { trip: PlainTrip });
 
@@ -43,7 +45,7 @@ export type PlannerCommand = PlannerRequest extends infer R
   : never;
 
 export type PlannerResponse =
-  | { id: number; type: "loaded"; stops: number; trips: number }
+  | { id: number; type: "loaded"; stops: number; trips: number; routes: RouteIndex; agencies: AgencyIndex }
   | { id: number; type: "planned"; journeys: PlainJourney[] }
   | { id: number; type: "stops"; stops: Stop[] }
   | { id: number; type: "error"; message: string };

--- a/test/unit/util.ts
+++ b/test/unit/util.ts
@@ -33,6 +33,9 @@ export function feed(
     links,
     interchange,
     stops,
+    routes: {},
+    agencies: {},
+    areas: {},
     feedInfo: { startDate: 20180101, endDate: 20201231 }
   };
 }

--- a/test/unit/worker/PlannerHost.spec.ts
+++ b/test/unit/worker/PlannerHost.spec.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { strToU8, zipSync } from "fflate";
 import { PlannerHost } from "../../../src/worker/PlannerHost.js";
-import type { PlannerCommand, PlannerEvent, PlannerRequest, PlannerResponse } from "../../../src/worker/Protocol.js";
+import type {
+  PlainTrip, PlannerCommand, PlannerEvent, PlannerRequest, PlannerResponse
+} from "../../../src/worker/Protocol.js";
 
 const FEED = {
   "stops.txt": "stop_id,stop_code,stop_name,stop_lat,stop_lon\nA,AAA,Ayton,1,2\nB,BBB,Beeton,3,4\n",
   "calendar.txt":
     "service_id,start_date,end_date,monday,tuesday,wednesday,thursday,friday,saturday,sunday\n"
     + "s1,20250101,20251231,1,1,1,1,1,1,1\n",
-  "trips.txt": "trip_id,service_id\nt1,s1\n",
+  "agency.txt": "agency_id,agency_name\n=OP,Operator Rail\n",
+  "routes.txt": "route_id,agency_id,route_short_name,route_long_name,route_type\nr1,=OP,OPR,Ayton to Beeton,2\n",
+  "trips.txt": "trip_id,route_id,service_id,trip_short_name,trip_headsign\nt1,r1,s1,OP1000,Beeton\n",
   "stop_times.txt":
     "trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type\n"
     + "t1,10:00:00,10:00:00,A,1,0,0\n"
@@ -16,11 +20,21 @@ const FEED = {
   "feed_info.txt": "feed_start_date,feed_end_date,feed_version\n20250101,20251231,1\n"
 };
 
-function feedZip(): Uint8Array<ArrayBuffer> {
+/** A feed that names neither a route nor an operator, which GTFS allows */
+const ANONYMOUS_FEED = {
+  ...FEED,
+  "agency.txt": undefined,
+  "routes.txt": undefined,
+  "trips.txt": "trip_id,service_id\nt1,s1\n"
+};
+
+function feedZip(files: Record<string, string | undefined> = FEED): Uint8Array<ArrayBuffer> {
   const contents: Record<string, Uint8Array> = {};
 
-  for (const [name, text] of Object.entries(FEED)) {
-    contents[name] = strToU8(text);
+  for (const [name, text] of Object.entries(files)) {
+    if (text !== undefined) {
+      contents[name] = strToU8(text);
+    }
   }
 
   return zipSync(contents);
@@ -112,6 +126,60 @@ describe("PlannerHost", () => {
     expect("t1").toBe(trip?.tripId);
     expect("s1").toBe(trip?.serviceId);
     expect(false).toBe(Object.hasOwn(trip as object, "service"));
+  });
+
+  /**
+   * The route and the two names are the loader's, and cross with the trip because they are data.
+   * A caller that has a Trip from loadGTFS reads the same three fields here.
+   */
+  it("carries the trip's route and its own names across with a leg", async () => {
+    const host = await loaded();
+    const response = await ask(host, {
+      type: "plan", origins: ["AAA"], destinations: ["BBB"],
+      date: new Date("2025-06-02").getTime(), time: 0
+    });
+
+    const leg = response.type === "planned" ? response.journeys[0].legs[0] : undefined;
+    const trip = (leg as { trip?: PlainTrip })?.trip;
+
+    expect("r1").toBe(trip?.routeId);
+    expect("OP1000").toBe(trip?.shortName);
+    expect("Beeton").toBe(trip?.headsign);
+  });
+
+  /**
+   * A leg names a route and stops there, so the indexes that turn that id into an operator are sent
+   * once with the load rather than denormalised onto every leg of every journey.
+   */
+  it("sends the routes and agencies of the feed when it loads", async () => {
+    const response = await ask(new PlannerHost(), { type: "load", feed: feedZip() });
+    const feed = response.type === "loaded" ? response : undefined;
+    const route = feed?.routes.r1;
+
+    expect("OPR").toBe(route?.shortName);
+    expect("Ayton to Beeton").toBe(route?.longName);
+    // the agency id is as the feed wrote it, leading = and all
+    expect("=OP").toBe(route?.agencyId);
+    expect("Operator Rail").toBe(feed?.agencies[route?.agencyId as string]?.name);
+  });
+
+  it("plans a feed that names neither a route nor an operator", async () => {
+    const host = new PlannerHost();
+    const load = await ask(host, { type: "load", feed: feedZip(ANONYMOUS_FEED) });
+
+    expect(0).toBe(load.type === "loaded" ? Object.keys(load.routes).length : -1);
+    expect(0).toBe(load.type === "loaded" ? Object.keys(load.agencies).length : -1);
+
+    const response = await ask(host, {
+      type: "plan", origins: ["AAA"], destinations: ["BBB"],
+      date: new Date("2025-06-02").getTime(), time: 0
+    });
+
+    const leg = response.type === "planned" ? response.journeys[0].legs[0] : undefined;
+    const trip = (leg as { trip?: PlainTrip })?.trip;
+
+    expect("t1").toBe(trip?.tripId);
+    expect(undefined).toBe(trip?.routeId);
   });
 
   it("returns something that survives being posted", async () => {


### PR DESCRIPTION
Closes #60.

`PlannerHost.toPlainLeg` rebuilt a trip from three fields, so a journey planned through
`PlannerClient` could say which trip it was on and nothing else about it. The
[comparison app](https://planarnetwork.github.io/journey-planning-comparison/) runs a second worker
purely to put that back, re-reading the same 21MB the planner already holds.

`@gb-transit/gtfs-loader` 1.2.0 landed the other half — planarnetwork/gb-transit#180 and #181 — so
this forwards it.

### A trip is now the trip, less its Service

```ts
export type PlainTrip = Omit<Trip, "service">;
```

A `Service` is a class and does not survive being posted; everything else a trip carries is data
and crosses as it is. Stating what is taken away rather than listing what is kept means `toPlainLeg`
is a rest destructure, and the next field the loader adds to `Trip` arrives on the other side
without this file being touched — under the name it has there, so code reading a `Trip` from
`loadGTFS` reads a `PlainTrip` the same way.

That brings `routeId`, `shortName` and `headsign` across. `Transfer` gained `mode` in the same
release, so a transfer leg now says how the change is made too.

### The routes and agencies come back with the load

A leg names the route its trip runs on and stops there, so something has to turn that id into an
operator. The GB feed has 98 routes and 41 agencies against 290,640 trips, so they are sent once,
whole, rather than a route name and an operator name being denormalised onto every leg of every
journey:

```js
const feed = await planner.load({ url: "/gtfs.zip" });
const { trip } = journey.legs[0];
const route = feed.routes[trip.routeId];

`${trip.shortName} to ${trip.headsign}, ${feed.agencies[route.agencyId].name}`;
// "GW130700 to Plymouth, GWR"
```

A feed need not name either, so `routeId` may be missing and the indexes empty.

### Verifying

The GB feed through `PlannerHost`, with every response put through `structuredClone` — the
algorithm `postMessage` uses:

```
load: 3.245s
stops 2795, trips 33626, routes 98, agencies 41

{ "origin": "PAD", "destination": "PLY",
  "tripId": "G14978_20260914_20261210", "routeId": "GW",
  "shortName": "GW130700", "headsign": "Plymouth",
  "route": "Great Western Railway", "operator": "GWR" }
```

The 09:03 Paddington to Plymouth, naming GWR, its headcode and its headsign. This was not run in an
actual browser worker, which #60 asks for; `structuredClone` is the same serialisation, but the
comparison app is where the literal check belongs.

Three specs cover it: the fields crossing with a leg, the indexes resolving route to agency — with
the `=GW`-form agency id kept as the feed wrote it — and a feed naming neither, which loads to empty
indexes and an undefined `routeId`.

`Agency`, `AgencyID`, `AgencyIndex`, `Route`, `RouteID` and `RouteIndex` are re-exported from
`index.ts` as the other loader types are.

https://claude.ai/code/session_015qmJpEZCq91XbLktWWTAQV
