### PR TITLE
Carry the feed's areas across the worker boundary

### DIFF
--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -1,0 +1,19 @@
+---
+"raptor-journey-planner": minor
+---
+
+Carry the feed's areas across the worker boundary.
+
+`load` now hands back an `areas` index alongside `routes` and `agencies` —
+`areas.txt` and `stop_areas.txt` read as one thing, which is where a group station
+lives. GTFS has no station of stations, so "London Terminals" is an area holding
+eighteen stops rather than a parent of them.
+
+The loader has parsed areas since `@gb-transit/gtfs-loader` 1.2.0, but the worker
+kept them: the feed stays inside it and only the journeys asked for come back, so
+the only way to a group station was to read the zip a second time. An area names
+stop ids and a query is asked in stations, so `stops()` still resolves one to the
+other; both now come from the same load.
+
+Additive — nothing that reads the existing fields changes. `Area`, `AreaID` and
+`AreaIndex` are re-exported for callers that want to name the type.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,29 @@ const route = feed.routes[trip.routeId];
 
 A feed need not name either, so `routeId` may be missing and the indexes empty.
 
+`load` hands back the feed's areas too — `areas.txt` and `stop_areas.txt` read as one thing. Nothing
+the algorithm does refers to one: an area is a fares construct, and no journey mentions it. It is
+here because a group station has nowhere else to live. GTFS has no station of stations —
+`parent_station` is forbidden on a station and the hierarchy is one level deep — so "London
+Terminals" is an area holding eighteen stops rather than a parent of them, and `transfers.txt` is
+the wrong tool for the job because it asserts a rider can walk between the two stops, which Euston
+and Waterloo are not.
+
+An area names stop ids as the feed wrote them, and a query is asked in stations, so `stops()`
+resolves one to the other. Both come from the same load, so planning between group stations needs
+no second reading of the zip:
+
+```js
+const feed = await planner.load({ url: "/gtfs.zip" });
+const stops = await planner.stops();
+const byId = new Map(stops.map(stop => [stop.id, stop]));
+
+const terminals = feed.areas["1072"].stops.map(id => byId.get(id).code);
+await planner.plan(["BTN"], terminals, new Date(), 9 * 60 * 60);
+```
+
+The index is empty for a feed with no `areas.txt`, which most feeds are.
+
 Passing `{ date }` to `load` restricts the timetable to that date, which makes it smaller and
 queries faster.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,9 @@ export type { LoadOptions, LoadProgress } from "@gb-transit/gtfs-loader";
 export { TimeParser } from "@gb-transit/gtfs-loader";
 export { addDays, daysBetween, getDateNumber, getDayOfWeek } from "@gb-transit/gtfs-loader";
 export type {
-  Agency, AgencyID, AgencyIndex, Calendar, CalendarIndex, DateIndex, DateNumber, DayOfWeek,
-  Duration, Interchange, Route, RouteID, RouteIndex, ServiceID, Stop, StopID, StopIndex, StopTime,
-  Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
+  Agency, AgencyID, AgencyIndex, Area, AreaID, AreaIndex, Calendar, CalendarIndex, DateIndex,
+  DateNumber, DayOfWeek, Duration, Interchange, Route, RouteID, RouteIndex, ServiceID, Stop, StopID,
+  StopIndex, StopTime, Time, Transfer, TransfersByOrigin, Trip, TripID, TripLink
 } from "@gb-transit/gtfs-loader";
 export * from "./query/DepartAfterQuery.js";
 export * from "./query/RangeQuery.js";

--- a/src/worker/PlannerClient.ts
+++ b/src/worker/PlannerClient.ts
@@ -1,4 +1,6 @@
-import type { AgencyIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time } from "@gb-transit/gtfs-loader";
+import type {
+  AgencyIndex, AreaIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time
+} from "@gb-transit/gtfs-loader";
 import {
   type FeedLocation,
   isEvent,
@@ -60,7 +62,8 @@ export class PlannerClient {
         stops: response.stops,
         trips: response.trips,
         routes: response.routes,
-        agencies: response.agencies
+        agencies: response.agencies,
+        areas: response.areas
       };
     }
     finally {
@@ -151,6 +154,16 @@ export class PlannerClient {
  * const route = feed.routes[leg.trip.routeId];
  * const operator = feed.agencies[route.agencyId].name;
  * ```
+ *
+ * The areas come with it for a different reason. Nothing in a journey refers to one - an area is a
+ * fares construct and the algorithm has no use for it - but a caller planning between group
+ * stations needs the stops of "London Terminals" to ask about them, and the feed stays inside the
+ * worker. Without this the only way to them is to read the zip a second time:
+ *
+ * ```js
+ * const terminals = feed.areas["1072"].stops;
+ * const journeys = await planner.plan(terminals, ["PLY"], date, time);
+ * ```
  */
 export interface LoadedFeed {
   /** Stations the timetable plans between */
@@ -160,4 +173,11 @@ export interface LoadedFeed {
   routes: RouteIndex;
   /** Agencies of the feed by agency id, which is what a route names */
   agencies: AgencyIndex;
+  /**
+   * Areas of the feed by area id - areas.txt and stop_areas.txt read as one thing.
+   *
+   * This is where a group station is: GTFS has no station of stations, so "London Terminals" is an
+   * area holding eighteen stops rather than a parent of them. Empty for a feed with no areas.txt.
+   */
+  areas: AreaIndex;
 }

--- a/src/worker/PlannerHost.ts
+++ b/src/worker/PlannerHost.ts
@@ -50,15 +50,18 @@ export class PlannerHost {
 
     this.network = createNetwork(this.feed, request.date === undefined ? undefined : new Date(request.date));
 
-    // the routes and agencies go back once, here, rather than a route name and an operator name
-    // being copied onto every leg of every journey planned afterwards
+    // the routes, agencies and areas go back once, here, rather than a route name and an operator
+    // name being copied onto every leg of every journey planned afterwards. They are small - the GB
+    // feed has under a hundred routes, 41 agencies and 729 areas - and there is no other way to
+    // reach them: the feed itself stays on this side.
     return {
       id: request.id,
       type: "loaded",
       stops: this.network.stopIds.length,
       trips: this.network.trips.length,
       routes: this.feed.routes,
-      agencies: this.feed.agencies
+      agencies: this.feed.agencies,
+      areas: this.feed.areas
     };
   }
 

--- a/src/worker/Protocol.ts
+++ b/src/worker/Protocol.ts
@@ -1,6 +1,6 @@
 import type { TimetableLeg } from "../results/Journey.js";
 import type {
-  AgencyIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time, Transfer, Trip
+  AgencyIndex, AreaIndex, GTFSSource, LoadProgress, RouteIndex, Stop, StopID, Time, Transfer, Trip
 } from "@gb-transit/gtfs-loader";
 
 /**
@@ -45,7 +45,10 @@ export type PlannerCommand = PlannerRequest extends infer R
   : never;
 
 export type PlannerResponse =
-  | { id: number; type: "loaded"; stops: number; trips: number; routes: RouteIndex; agencies: AgencyIndex }
+  | {
+      id: number; type: "loaded"; stops: number; trips: number;
+      routes: RouteIndex; agencies: AgencyIndex; areas: AreaIndex;
+    }
   | { id: number; type: "planned"; journeys: PlainJourney[] }
   | { id: number; type: "stops"; stops: Stop[] }
   | { id: number; type: "error"; message: string };

--- a/test/unit/worker/PlannerHost.spec.ts
+++ b/test/unit/worker/PlannerHost.spec.ts
@@ -17,7 +17,16 @@ const FEED = {
     "trip_id,arrival_time,departure_time,stop_id,stop_sequence,pickup_type,drop_off_type\n"
     + "t1,10:00:00,10:00:00,A,1,0,0\n"
     + "t1,10:30:00,10:30:00,B,2,0,0\n",
-  "feed_info.txt": "feed_start_date,feed_end_date,feed_version\n20250101,20251231,1\n"
+  "feed_info.txt": "feed_start_date,feed_end_date,feed_version\n20250101,20251231,1\n",
+  "areas.txt": "area_id,area_name\ng1,Ayton and Beeton\n",
+  "stop_areas.txt": "area_id,stop_id\ng1,A\ng1,B\n"
+};
+
+/** A feed with no areas.txt, which most feeds are */
+const UNGROUPED_FEED = {
+  ...FEED,
+  "areas.txt": undefined,
+  "stop_areas.txt": undefined
 };
 
 /** A feed that names neither a route nor an operator, which GTFS allows */
@@ -161,6 +170,49 @@ describe("PlannerHost", () => {
     // the agency id is as the feed wrote it, leading = and all
     expect("=OP").toBe(route?.agencyId);
     expect("Operator Rail").toBe(feed?.agencies[route?.agencyId as string]?.name);
+  });
+
+  /**
+   * An area is a fares construct and no journey refers to one, but a caller planning between group
+   * stations needs its stops, and the feed itself never leaves this side.
+   */
+  it("sends the areas of the feed when it loads", async () => {
+    const response = await ask(new PlannerHost(), { type: "load", feed: feedZip() });
+    const area = response.type === "loaded" ? response.areas.g1 : undefined;
+
+    expect("Ayton and Beeton").toBe(area?.name);
+    expect(["A", "B"]).toEqual(area?.stops);
+  });
+
+  /**
+   * Which is what makes a group station plannable. An area names stop ids, as the feed wrote them,
+   * and a query is asked in the stations those resolve to - the mapping the stops reply is there to
+   * provide. Both come from this one load, so neither needs the zip read a second time.
+   */
+  it("plans into the stations of an area it sent back", async () => {
+    const host = new PlannerHost();
+    const load = await ask(host, { type: "load", feed: feedZip() });
+    const listed = await ask(host, { type: "stops" });
+
+    const stops = listed.type === "stops" ? listed.stops : [];
+    const area = load.type === "loaded" ? load.areas.g1.stops : [];
+    const destinations = area.map(id => stops.find(stop => stop.id === id)?.code as string);
+
+    expect(["AAA", "BBB"]).toEqual(destinations);
+
+    const response = await ask(host, {
+      type: "plan", origins: ["AAA"], destinations,
+      date: new Date("2025-06-02").getTime(), time: 0
+    });
+
+    expect("planned").toBe(response.type);
+    expect(1).toBe(response.type === "planned" ? response.journeys.length : 0);
+  });
+
+  it("sends no areas for a feed that has none", async () => {
+    const response = await ask(new PlannerHost(), { type: "load", feed: feedZip(UNGROUPED_FEED) });
+
+    expect(0).toBe(response.type === "loaded" ? Object.keys(response.areas).length : -1);
   });
 
   it("plans a feed that names neither a route nor an operator", async () => {


### PR DESCRIPTION
`load` now hands back an `areas` index alongside `routes` and `agencies`.

## Why

This is where a group station lives. GTFS has no station of stations —
`parent_station` is forbidden on a `location_type=1` station and the hierarchy is
exactly one level deep — so "London Terminals" is an area holding eighteen stops
rather than a parent of them. `transfers.txt` is the wrong tool for the same job:
it asserts a rider can get between the two stops, which is false for Euston and
Waterloo.

`@gb-transit/gtfs-loader` has parsed `areas.txt` and `stop_areas.txt` since 1.2.0,
and `PlannerHost` has had `this.feed.areas` sitting in front of it ever since. It
just never sent them. Because the feed stays inside the worker and only the
journeys asked for come back, the only way to reach a group station was to read
the zip a second time — exactly the thing #61 removed for routes and operators.
railplan-lab is doing that today, and this is what lets it stop.

## What changes

- `PlannerResponse` `loaded` carries `areas: AreaIndex`, and `PlannerHost` fills it
  from the feed it already has.
- `LoadedFeed` gains `areas`, so `PlannerClient.load` returns it.
- `Area`, `AreaID` and `AreaIndex` are re-exported, as the other loader types are.
- README section and a `minor` changeset.

Additive — nothing that reads the existing fields is affected, and the algorithm
is untouched.

## The one wrinkle

An area names stop ids as the feed wrote them, and a query is asked in stations,
so a caller resolves one to the other through `stops()`. That is left to the
caller rather than resolved here, so `areas` reads as the feed wrote it — the same
way `routes` keeps the agency id with its leading `=`. Both come from the same
load, so it costs no extra reading:

```js
const feed = await planner.load({ url: "/gtfs.zip" });
const stops = await planner.stops();
const byId = new Map(stops.map(stop => [stop.id, stop]));

const terminals = feed.areas["1072"].stops.map(id => byId.get(id).code);
await planner.plan(["BTN"], terminals, new Date(), 9 * 60 * 60);
```

## Testing

Four new `PlannerHost` specs — the areas come back, they resolve to stations and
plan, a feed with no `areas.txt` gets an empty index. 231 tests pass, lint and
typecheck clean.

Checked against the real gb-transit feed too: 729 areas come across, `1072`
resolves to its 18 terminals, and `BTN` → those 18 returns a journey into each.
The `loaded` reply still survives `structuredClone`, so it genuinely crosses the
boundary.

https://claude.ai/code/session_01DaV4vVj18ny517PskiuJwg