### PR TITLE
Put a journey found over more than one day onto one clock

### DIFF
--- a/.changeset/quiet-trains-arrive.md
+++ b/.changeset/quiet-trains-arrive.md
@@ -1,0 +1,29 @@
+---
+"raptor-journey-planner": patch
+---
+
+Put a journey found over more than one day onto one clock.
+
+A query that finds nothing on the day it is asked for searches the next one, and
+stitches the two days together. The stitched journey's `arrivalTime` already
+carried the day it gained, but its legs did not: each day is scanned on its own
+and hands back the times the feed writes for it, which count from that day's
+midnight. So the second day's legs sat a day behind the first day's.
+
+Anything reading the legs rather than the journey's own two times saw a journey
+that arrived before it departed — a leg arriving at B at 1035 and the next one
+leaving B at 1030 — and every duration taken from them came out short by a day,
+or negative.
+
+The legs of the following day are now moved forward a day as they are merged, so
+that every time in a journey counts in seconds from the midnight it departed and
+runs past a day rather than wrapping. That is how a feed writes an overnight trip
+already: a train leaving at 23:50 and arriving twenty minutes into the next day
+arrives at 24:10. A duration is a subtraction either way.
+
+The stop times are copied rather than adjusted in place, since they are the
+feed's own and shared with every other journey over the same trip. A transfer is
+left alone, the times it carries being the window it is available in rather than
+when it was made.
+
+`isTimetableLeg` is now exported, for callers that walk a journey's legs.

--- a/src/query/GroupStationDepartAfterQuery.ts
+++ b/src/query/GroupStationDepartAfterQuery.ts
@@ -5,10 +5,16 @@ import type { Network } from "../network/Network.js";
 import type { ResultsFactory } from "../results/ResultsFactory.js";
 import { checkCovered } from "../network/TripCalendar.js";
 import { getDateNumber } from "@gb-transit/gtfs-loader";
-import type { Journey } from "../results/Journey.js";
+import { isTimetableLeg } from "../results/Journey.js";
+import type { AnyLeg, Journey } from "../results/Journey.js";
 import type { JourneyFilter } from "../results/filter/JourneyFilter.js";
 import { NOT_REACHED, type StopIdx } from "../network/Timetable.js";
 import type { Arrivals } from "../raptor/ScanResults.js";
+
+/**
+ * Seconds in a day
+ */
+const DAY = 86400;
 
 /**
  * Implementation of Raptor that searches for journeys between a set of origin and destinations.
@@ -79,7 +85,7 @@ export class GroupStationDepartAfterQuery {
     // create the origin departure times by subtracting 1 day from the best arrival time
     for (let stop = 0; stop < kConnections.length; stop++) {
       if (kConnections[stop].length > 0 && bestArrivals[stop] !== NOT_REACHED) {
-        origins.set(stop, Math.max(1, bestArrivals[stop] - 86400));
+        origins.set(stop, Math.max(1, bestArrivals[stop] - DAY));
       }
     }
 
@@ -132,9 +138,37 @@ export class GroupStationDepartAfterQuery {
    */
   private mergeJourneys(journeyA: Journey, journeyB: Journey): Journey {
     return {
-      legs: journeyA.legs.concat(journeyB.legs),
+      legs: journeyA.legs.concat(journeyB.legs.map(leg => this.nextDay(leg))),
       departureTime: journeyA.departureTime,
-      arrivalTime: journeyB.arrivalTime + 86400
+      arrivalTime: journeyB.arrivalTime + DAY
+    };
+  }
+
+  /**
+   * A leg from the following day's scan, moved onto the clock the journey departed on.
+   *
+   * Every time in a journey counts from the midnight it started at and runs past a day rather than
+   * wrapping, but each day is scanned on its own and hands back the times the feed writes for it,
+   * which count from that day's midnight. Left alone, the second day's legs sit a day behind the
+   * first day's and every duration taken from them - the journey's, a change's, a leg's - comes out
+   * short by a day, or negative.
+   *
+   * The stop times are copied rather than adjusted in place: they are the feed's own, shared with
+   * every other journey over the same trip. A transfer is left alone, since the times it carries
+   * are the window it is available in rather than when it was made.
+   */
+  private nextDay(leg: AnyLeg): AnyLeg {
+    if (!isTimetableLeg(leg)) {
+      return leg;
+    }
+
+    return {
+      ...leg,
+      stopTimes: leg.stopTimes.map(stopTime => ({
+        ...stopTime,
+        arrivalTime: stopTime.arrivalTime + DAY,
+        departureTime: stopTime.departureTime + DAY
+      }))
     };
   }
 

--- a/src/results/Journey.ts
+++ b/src/results/Journey.ts
@@ -25,10 +25,22 @@ export interface TimetableLeg extends Leg {
 export type AnyLeg = Transfer | TimetableLeg;
 
 /**
- * A journey is a collection of legs
+ * A journey is a collection of legs.
+ *
+ * Every time in one counts in seconds from the midnight the journey departed, and keeps counting
+ * past a day rather than wrapping, which is how a feed writes an overnight trip anyway: a train
+ * leaving at 23:50 and arriving twenty minutes into the next day arrives at 24:10. A duration is
+ * therefore always a subtraction, whether or not the journey crosses midnight.
  */
 export interface Journey {
   legs: AnyLeg[];
   departureTime: Time,
   arrivalTime: Time
+}
+
+/**
+ * A leg taken on a vehicle carries the stop times it covers; one taken on foot has none
+ */
+export function isTimetableLeg(leg: AnyLeg): leg is TimetableLeg {
+  return (leg as TimetableLeg).stopTimes !== undefined;
 }

--- a/src/results/JourneyFactory.ts
+++ b/src/results/JourneyFactory.ts
@@ -4,7 +4,8 @@ import type { StopIdx } from "../network/Timetable.js";
 import type { Network } from "../network/Network.js";
 import { originIndexOf, stopTimesOf, tripOf } from "../raptor/Connection.js";
 import type { ResultsFactory } from "./ResultsFactory.js";
-import type { AnyLeg, Journey, TimetableLeg } from "./Journey.js";
+import { isTimetableLeg } from "./Journey.js";
+import type { AnyLeg, Journey } from "./Journey.js";
 
 /**
  * Extracts journeys from the kConnections index.
@@ -69,7 +70,7 @@ export class JourneyFactory implements ResultsFactory {
     let transferDuration = 0;
 
     for (const leg of legs) {
-      if (!this.isTimetableLeg(leg)) {
+      if (!isTimetableLeg(leg)) {
         transferDuration += leg.duration;
       }
       else {
@@ -86,7 +87,7 @@ export class JourneyFactory implements ResultsFactory {
     for (let i = legs.length - 1; i >= 0; i--) {
       const leg = legs[i];
 
-      if (!this.isTimetableLeg(leg)) {
+      if (!isTimetableLeg(leg)) {
         transferDuration += leg.duration;
       }
       else {
@@ -95,9 +96,5 @@ export class JourneyFactory implements ResultsFactory {
     }
 
     return 0;
-  }
-
-  private isTimetableLeg(connection: AnyLeg): connection is TimetableLeg {
-    return (connection as TimetableLeg).stopTimes !== undefined;
   }
 }

--- a/test/unit/query/DepartAfterQuery.spec.ts
+++ b/test/unit/query/DepartAfterQuery.spec.ts
@@ -915,12 +915,14 @@ describe("DepartAfterQuery", () => {
 
     setDefaultTrip(result);
 
+    // the second leg is tomorrow's, so it leaves B a day after the first leg gets in rather than
+    // five minutes before
     const expected = j([
       st("A", null, 1000),
       st("B", 1035, 1035),
     ], [
-      st("B", 1030, 1030),
-      st("E", 1100, null)
+      st("B", 1030 + 86400, 1030 + 86400),
+      st("E", 1100 + 86400, null)
     ]);
 
     expect(result[0].legs).toEqual(expected.legs);
@@ -1000,18 +1002,20 @@ describe("DepartAfterQuery", () => {
     const result = query.plan("A", "E", new Date("2019-04-23"), 900);
 
     setDefaultTrip(result);
+
+    // in both, everything after the first leg is the next day's and carries a day with it
     const change = j(
       [
         st("A", null, 1900),
         st("B", 1930, 1935)
       ],
       [
-        st("B", null, 1035),
-        st("D", 1100, null)
+        st("B", null, 1035 + 86400),
+        st("D", 1100 + 86400, null)
       ],
       [
-        st("D", null, 1100),
-        st("E", 1130, null)
+        st("D", null, 1100 + 86400),
+        st("E", 1130 + 86400, null)
       ]
     );
 
@@ -1022,21 +1026,12 @@ describe("DepartAfterQuery", () => {
         st("C", 2000, null)
       ],
       [
-        st("C", null, 1130),
-        st("E", 1200, null)
+        st("C", null, 1130 + 86400),
+        st("E", 1200 + 86400, null)
       ]
     );
 
-    const expected = [
-      noChange,
-      change,
-    ];
-
-    for (const journey of expected) {
-      journey.arrivalTime += 86400;
-    }
-
-    expect(result).toEqual(expected);
+    expect(result).toEqual([noChange, change]);
   });
 
   it("does not return overnight journeys that cannot be made", () => {

--- a/test/unit/query/GroupStationDepartAfterQuery.spec.ts
+++ b/test/unit/query/GroupStationDepartAfterQuery.spec.ts
@@ -106,6 +106,40 @@ describe("GroupStationDepartAfterQuery", () => {
     ]);
   });
 
+  it("puts a journey found over two days onto one clock", () => {
+    const trips = [
+      t(
+        st("A", null, 1000),
+        st("B", 1030, null)
+      ),
+      // the only way on to C leaves before the train from A gets in, so it is tomorrow's
+      t(
+        st("B", null, 500),
+        st("C", 600, null)
+      )
+    ];
+
+    const network = createNetwork(feed(trips));
+    const query = new GroupStationDepartAfterQuery(network, journeyFactory, 2, filters);
+    const result = query.plan(["A"], ["C"], new Date("2019-04-18"), 900);
+
+    setDefaultTrip(result);
+
+    // the second day's legs are a day on from the first day's, rather than back at its midnight
+    expect(result).toEqual([
+      j(
+        [
+          st("A", null, 1000),
+          st("B", 1030, null)
+        ],
+        [
+          st("B", null, 86900),
+          st("C", 87000, null)
+        ]
+      )
+    ]);
+  });
+
   it("plans from multiple origins", () => {
     const trips = [
       t(


### PR DESCRIPTION
A query that finds nothing on the day it is asked for searches the next one and stitches the two days together in `GroupStationDepartAfterQuery.mergeJourneys`. The stitched journey's `arrivalTime` already carried the day it gained; its legs did not.

Each day is scanned on its own and hands back the times the feed writes for it, which count from that day's midnight, so the second day's legs sat a day behind the first day's. Anything reading the legs rather than the journey's own two times saw a journey that arrived before it departed. The existing spec said so out loud:

```js
const expected = j([
  st("A", null, 1000),
  st("B", 1035, 1035),   // in to B at 1035
], [
  st("B", 1030, 1030),   // out of B at 1030, the following morning
  st("E", 1100, null)
]);
```

Downstream that is a change of minus five minutes, and on a real feed a London–Fort William query at 18:00 came back with a negative journey time.

## The fix

The following day's legs are moved forward a day as they are merged, so that every time in a journey counts in seconds from the midnight it departed and runs past a day rather than wrapping. That is how a feed writes an overnight trip anyway — a train leaving at 23:50 and arriving twenty minutes into the next day arrives at 24:10 — so a duration stays a subtraction whether or not the journey crosses midnight. It composes over more than two days: each merge moves the whole accumulated tail on by one more day, in step with the day already added to `arrivalTime`.

The stop times are copied rather than adjusted in place, since they are the feed's own and shared with every other journey over the same trip. A transfer is left alone: the times it carries are the window it is available in, not when it was made.

`isTimetableLeg` moves out of `JourneyFactory` into `Journey.ts` and is exported, since both places now need it and a caller walking a journey's legs does too.

## Tests

- A new spec in `GroupStationDepartAfterQuery` covering the two-day merge directly. Without the fix it reports the second day's legs at 500/600 rather than 86900/87000.
- The two `DepartAfterQuery` specs that asserted the old leg times now assert the corrected ones. `adds a day to the arrival time of journeys that are made overnight` is untouched and still passes — the journey's own `arrivalTime` was always right.

107 passing, lint and typecheck clean.

## Note, not fixed here

`getJourneys` calls `startDate.setDate(startDate.getDate() + 1)` on the `Date` the caller passed to `plan`, so a multi-day search advances the caller's own object. It is invisible through `PlannerClient`, where the date is cloned across the worker boundary, but not to anyone calling `plan` in process. Happy to fix it in this PR or a separate one, whichever you prefer.

https://claude.ai/code/session_01QCqmsDEXk2AeFhHbeKhbZQ
